### PR TITLE
Dg/add null check for graphics in component

### DIFF
--- a/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
+++ b/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
@@ -52,48 +52,53 @@ export const VerticalContentPanelServer = async ({ module, languageCode }: Unloa
 
 			<div className="mx-auto mt-14 max-w-6xl">
 				<div className={clsx("space-y-12")}>
-					{panels.map((panel, index) => (
-						<div
-							key={panel.title}
-							className={clsx(
-								"flex flex-col-reverse gap-6 md:flex-row md:px-12 lg:gap-12",
-								textSide === "left"
-									? "md:odd:flex-row md:even:flex-row-reverse"
-									: "md:odd:flex-row-reverse md:even:flex-row"
-							)}
-						>
-							<div className={clsx("group relative block text-left", "m-auto md:w-2/3")}>
-								<h4 className={clsx("text-2xl font-medium")}>{panel.title}</h4>
-
-								<div
-									className="prose mt-4 max-w-full"
-									dangerouslySetInnerHTML={renderHTMLCustom(panel.description)}
-								></div>
-							</div>
-							<div className="flex items-center justify-center md:w-1/3">
-								{!panel || !panel.graphic ? (
-									<MissingImage />
-								) : (
-									<>
-										{panel.graphic.url.endsWith(".svg") ? (
-											<img
-												src={panel.graphic.url}
-												alt={panel.graphic.label}
-												className="max-h-[300px] w-full max-w-[300px]"
-											/>
-										) : (
-											<AgilityPic
-												image={panel.graphic}
-												className="max-h-[300px] w-full max-w-[300px]"
-												fallbackWidth={300}
-												sources={[{ media: "(min-resolution: 2x)", width: 600 }]}
-											/>
-										)}
-									</>
+					{panels.map((panel, index) => {
+						if (!panel.graphic) {
+							console.log(`panel ${panel.title || index} is missing a graphic`)
+						}
+						return (
+							<div
+								key={panel.title}
+								className={clsx(
+									"flex flex-col-reverse gap-6 md:flex-row md:px-12 lg:gap-12",
+									textSide === "left"
+										? "md:odd:flex-row md:even:flex-row-reverse"
+										: "md:odd:flex-row-reverse md:even:flex-row"
 								)}
+							>
+								<div className={clsx("group relative block text-left", "m-auto md:w-2/3")}>
+									<h4 className={clsx("text-2xl font-medium")}>{panel.title}</h4>
+
+									<div
+										className="prose mt-4 max-w-full"
+										dangerouslySetInnerHTML={renderHTMLCustom(panel.description)}
+									></div>
+								</div>
+								<div className="flex items-center justify-center md:w-1/3">
+									{!panel || !panel.graphic ? (
+										<MissingImage />
+									) : (
+										<>
+											{panel.graphic.url.endsWith(".svg") ? (
+												<img
+													src={panel.graphic.url}
+													alt={panel.graphic.label}
+													className="max-h-[300px] w-full max-w-[300px]"
+												/>
+											) : (
+												<AgilityPic
+													image={panel.graphic}
+													className="max-h-[300px] w-full max-w-[300px]"
+													fallbackWidth={300}
+													sources={[{ media: "(min-resolution: 2x)", width: 600 }]}
+												/>
+											)}
+										</>
+									)}
+								</div>
 							</div>
-						</div>
-					))}
+						)
+					})}
 				</div>
 			</div>
 		</Container>

--- a/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
+++ b/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
@@ -25,7 +25,7 @@ interface IVerticalContentPanel {
 	}
 }
 
-export const VerticalContentPanelServer = async ({ module, languageCode }: UnloadedModuleProps) => {
+export const VerticalContentPanelServer = async ({ module, languageCode, isPreview }: UnloadedModuleProps) => {
 	const { fields, contentID } = await getContentItem<IVerticalContentPanel>({
 		contentID: module.contentid,
 		languageCode
@@ -76,7 +76,7 @@ export const VerticalContentPanelServer = async ({ module, languageCode }: Unloa
 								</div>
 								<div className="flex items-center justify-center md:w-1/3">
 									{!panel || !panel.graphic ? (
-										<MissingImage />
+										<MissingImage isPreview={isPreview} />
 									) : (
 										<>
 											{panel.graphic.url.endsWith(".svg") ? (

--- a/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
+++ b/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
@@ -7,6 +7,7 @@ import { getContentItem } from "lib/cms/getContentItem"
 import { getContentList } from "lib/cms/getContentList"
 import clsx from "clsx"
 import { renderHTMLCustom } from "lib/utils/renderHtmlCustom"
+import { MissingImage } from "../VisualFeedback/MissingImage"
 
 interface VerticalPanel {
 	title: string
@@ -70,19 +71,25 @@ export const VerticalContentPanelServer = async ({ module, languageCode }: Unloa
 								></div>
 							</div>
 							<div className="flex items-center justify-center md:w-1/3">
-								{panel.graphic.url.endsWith(".svg") ? (
-									<img
-										src={panel.graphic.url}
-										alt={panel.graphic.label}
-										className="max-h-[300px] w-full max-w-[300px]"
-									/>
+								{!panel || !panel.graphic ? (
+									<MissingImage />
 								) : (
-									<AgilityPic
-										image={panel.graphic}
-										className="max-h-[300px] w-full max-w-[300px]"
-										fallbackWidth={300}
-										sources={[{ media: "(min-resolution: 2x)", width: 600 }]}
-									/>
+									<>
+										{panel.graphic.url.endsWith(".svg") ? (
+											<img
+												src={panel.graphic.url}
+												alt={panel.graphic.label}
+												className="max-h-[300px] w-full max-w-[300px]"
+											/>
+										) : (
+											<AgilityPic
+												image={panel.graphic}
+												className="max-h-[300px] w-full max-w-[300px]"
+												fallbackWidth={300}
+												sources={[{ media: "(min-resolution: 2x)", width: 600 }]}
+											/>
+										)}
+									</>
 								)}
 							</div>
 						</div>

--- a/components/agility-components/VisualFeedback/MissingImage.tsx
+++ b/components/agility-components/VisualFeedback/MissingImage.tsx
@@ -1,20 +1,24 @@
 import React from "react"
 
 interface IMissingImageProps {
-	// Define props here
+	isPreview: boolean
 }
 
-const MissingImage: React.FC<IMissingImageProps> = () => {
-	return (
-		<div className="flex w-full items-center justify-center rounded border-2 border-red-400 bg-red-50 p-4 text-center text-lg text-slate-500">
-			<div>
-				<h1 className="mb-2 font-medium">
-					Image Not Found <span>😢</span>
-				</h1>
-				<p className="text-sm">Please double check the content item before publishing.</p>
+const MissingImage: React.FC<IMissingImageProps> = ({ isPreview }) => {
+	if (isPreview) {
+		return (
+			<div className="flex w-full items-center justify-center rounded border-2 border-red-400 bg-red-50 p-4 text-center text-lg text-slate-500">
+				<div>
+					<h1 className="mb-2 font-medium">
+						Image Not Found <span>😢</span>
+					</h1>
+					<p className="text-sm">Please double check the content item before publishing.</p>
+				</div>
 			</div>
-		</div>
-	)
+		)
+	} else {
+		return null
+	}
 }
 
 export { MissingImage }

--- a/components/agility-components/VisualFeedback/MissingImage.tsx
+++ b/components/agility-components/VisualFeedback/MissingImage.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+
+interface IMissingImageProps {
+	// Define props here
+}
+
+const MissingImage: React.FC<IMissingImageProps> = () => {
+	return (
+		<div className="flex w-full items-center justify-center rounded border-2 border-red-400 bg-red-50 p-4 text-center text-lg text-slate-500">
+			<div>
+				<h1 className="mb-2 font-medium">
+					Image Not Found <span>😢</span>
+				</h1>
+				<p className="text-sm">Please double check the content item before publishing.</p>
+			</div>
+		</div>
+	)
+}
+
+export { MissingImage }

--- a/styles/output.css
+++ b/styles/output.css
@@ -3307,6 +3307,31 @@ h2 {
   border-color: rgb(228 228 231 / var(--tw-border-opacity));
 }
 
+.border-red-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity));
+}
+
+.border-red-900 {
+  --tw-border-opacity: 1;
+  border-color: rgb(127 29 29 / var(--tw-border-opacity));
+}
+
+.border-red-700 {
+  --tw-border-opacity: 1;
+  border-color: rgb(185 28 28 / var(--tw-border-opacity));
+}
+
+.border-red-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(220 38 38 / var(--tw-border-opacity));
+}
+
+.border-red-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(248 113 113 / var(--tw-border-opacity));
+}
+
 .border-b-gray-200 {
   --tw-border-opacity: 1;
   border-bottom-color: rgb(229 231 235 / var(--tw-border-opacity));
@@ -3538,6 +3563,11 @@ h2 {
 .bg-zinc-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(250 250 250 / var(--tw-bg-opacity));
+}
+
+.bg-red-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 242 242 / var(--tw-bg-opacity));
 }
 
 .bg-opacity-0 {


### PR DESCRIPTION
Added a null check in `components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx` to prevent missing graphics from causing a full page error. Also added a console.warn and a Visual Feedback component to let the editor know they're missing an image. 

<img width="1920" alt="Screenshot 2025-02-05 at 2 58 48 PM" src="https://github.com/user-attachments/assets/b23ea477-f725-4d88-8e68-a5fab2ab1e07" />
