### PR TITLE
Add Splash Image Component for Editors

### DIFF
--- a/components/agility-components/SplashImage/SplashImage.tsx
+++ b/components/agility-components/SplashImage/SplashImage.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { AgilityPic, ImageField, UnloadedModuleProps } from "@agility/nextjs"
+
+import { getContentItem } from "lib/cms/getContentItem"
+
+interface ISplashImageProps {
+	splashImage: ImageField
+}
+
+export const SplashImage = async ({ module, languageCode }: UnloadedModuleProps) => {
+	const { fields, contentID } = await getContentItem<ISplashImageProps>({
+		contentID: module.contentid,
+		languageCode
+	})
+
+	return (
+		<div data-agility-component={contentID} className="mx-auto max-w-7xl">
+			{fields.splashImage && (
+				<div className="flex w-full justify-center">
+					<AgilityPic
+						image={fields.splashImage}
+						data-agility-field="splashImage"
+						fallbackWidth={400}
+						priority
+						className="w-full"
+						sources={[
+							//screen at least than 640, it's 1/2 of the screen, so the same size as the prev breakpoint
+							{ media: "(min-width: 1200px) and (min-resolution: 2x)", width: 1600 },
+							{ media: "(min-width: 1200px)", width: 800 },
+							{ media: "(min-width: 1024px) and (min-resolution: 2x)", width: 1200 },
+							{ media: "(min-width: 1024px)", width: 600 },
+							{ media: "(min-width: 768px) and (min-resolution: 2x)", width: 1200 },
+							{ media: "(min-width: 768px)", width: 600 },
+							{ media: "(min-width: 640px) and (min-resolution: 2x)", width: 880 },
+							{ media: "(min-width: 640px)", width: 480 },
+							{ media: "(min-width: 320px) and (min-resolution: 2x)", width: 640 }
+						]}
+					/>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/components/agility-components/index.ts
+++ b/components/agility-components/index.ts
@@ -1,81 +1,78 @@
-import RichTextArea from "./RichTextArea";
+import RichTextArea from "./RichTextArea"
 
-import PostDetails from "./PostDetails";
-import Heading from "./Heading";
-import TextBlockWithImage from "./TextBlockWithImage";
-import NoComponentFound from "./NoComponentFound";
-import { CenteredContentPanel } from "./CenteredContentPanel";
-import { LogoListingModule } from "./LogoListingModule/LogoListingModule.server";
+import PostDetails from "./PostDetails"
+import Heading from "./Heading"
+import TextBlockWithImage from "./TextBlockWithImage"
+import NoComponentFound from "./NoComponentFound"
+import { CenteredContentPanel } from "./CenteredContentPanel"
+import { LogoListingModule } from "./LogoListingModule/LogoListingModule.server"
 
-import { VerticalContentPanelServer } from "./VerticalContentPanel/VerticalContentPanel.server";
-import SingleTestimonialPanel from "./SingleTestimonialPanel";
-import CaseStudyRotator from "./CaseStudyRotator/CaseStudyRotator";
-import CenteredCTAPanel from "./CenteredCTAPanel";
-import RightORLeftContentModule from "./RightORLeftContentModule";
-import TriplePanelComparisonModule from "./TriplePanelComparisonModule";
-import RightOrLeftSteps from "./RightOrLeftSteps";
-import FeaturedResources from "./FeaturedResources";
-import NewIntegrationListingModule from "./IntegrationListingModule/NewIntegrationListingModule";
-import { TwoPanelFeatureComparison } from "./TwoPanelFeatureComparison/TwoPanelFeatureComparison.server";
-import { Faqs } from "./Faqs";
-import { TriplePanelModule } from "./TriplePanelModule";
-import { GuideLinks } from "./GuideLinks";
-import { NewIntegrationModule } from "./NewIntegrationModule";
-import { RightOrLeftCaseStudyTestimonial } from "./RightOrLeftCaseStudyTestimonial";
-import { TwoBoxContent } from "./2BoxContent";
-import { G2CrowdReviewListing } from "./G2CrowdReviewListing/G2CrowdReviewListing";
-import { CaseStudyListing } from "./CaseStudyListing/CaseStudyListing";
-import { CaseStudyContentPanel } from "./CaseStudyDetails/CaseStudyContentPanel";
-import { CaseStudyDetails } from "./CaseStudyDetails/CaseStudyDetails";
-import { CaseStudyTechStack } from "./CaseStudyDetails/CaseStudyTechStack";
-import { PartnerListing } from "./PartnerListing/PartnerListing";
-import { PartnerContentPanel } from "./PartnerDetails/PartnerContentPanel";
-import { PartnerDetails } from "./PartnerDetails/PartnerDetails";
-import { Testimonials } from "./Testimonials/Testimonials";
-import { SubmissionForm } from "./SubmissionForm/SubmissionForm";
-import { TypeFormModule } from "./TypeFormModule/TypeFormModule";
-import { PricingPackagesModule } from "./Pricing/PricingPackagesModule";
-import { NEWFeaturedResource } from "./NEWFeaturedResource";
-import { NEWDownloadableeBooks } from "./NEWDownloadableeBooks";
-import { NEWWebinarDownload } from "./NEWWebinarDownload";
-import { ScheduleADemo } from "./ScheduleADemo/ScheduleADemo";
-import { Hero } from "./Hero/Hero";
-import { RightLeftContent } from "components/RightLeftContent";
-import { LogoListing } from "./LogoListing/LogoListing.server";
+import { VerticalContentPanelServer } from "./VerticalContentPanel/VerticalContentPanel.server"
+import SingleTestimonialPanel from "./SingleTestimonialPanel"
+import CaseStudyRotator from "./CaseStudyRotator/CaseStudyRotator"
+import CenteredCTAPanel from "./CenteredCTAPanel"
+import RightORLeftContentModule from "./RightORLeftContentModule"
+import TriplePanelComparisonModule from "./TriplePanelComparisonModule"
+import RightOrLeftSteps from "./RightOrLeftSteps"
+import FeaturedResources from "./FeaturedResources"
+import NewIntegrationListingModule from "./IntegrationListingModule/NewIntegrationListingModule"
+import { TwoPanelFeatureComparison } from "./TwoPanelFeatureComparison/TwoPanelFeatureComparison.server"
+import { Faqs } from "./Faqs"
+import { TriplePanelModule } from "./TriplePanelModule"
+import { GuideLinks } from "./GuideLinks"
+import { NewIntegrationModule } from "./NewIntegrationModule"
+import { RightOrLeftCaseStudyTestimonial } from "./RightOrLeftCaseStudyTestimonial"
+import { TwoBoxContent } from "./2BoxContent"
+import { G2CrowdReviewListing } from "./G2CrowdReviewListing/G2CrowdReviewListing"
+import { CaseStudyListing } from "./CaseStudyListing/CaseStudyListing"
+import { CaseStudyContentPanel } from "./CaseStudyDetails/CaseStudyContentPanel"
+import { CaseStudyDetails } from "./CaseStudyDetails/CaseStudyDetails"
+import { CaseStudyTechStack } from "./CaseStudyDetails/CaseStudyTechStack"
+import { PartnerListing } from "./PartnerListing/PartnerListing"
+import { PartnerContentPanel } from "./PartnerDetails/PartnerContentPanel"
+import { PartnerDetails } from "./PartnerDetails/PartnerDetails"
+import { Testimonials } from "./Testimonials/Testimonials"
+import { SubmissionForm } from "./SubmissionForm/SubmissionForm"
+import { TypeFormModule } from "./TypeFormModule/TypeFormModule"
+import { PricingPackagesModule } from "./Pricing/PricingPackagesModule"
+import { NEWFeaturedResource } from "./NEWFeaturedResource"
+import { NEWDownloadableeBooks } from "./NEWDownloadableeBooks"
+import { NEWWebinarDownload } from "./NEWWebinarDownload"
+import { ScheduleADemo } from "./ScheduleADemo/ScheduleADemo"
+import { Hero } from "./Hero/Hero"
+import { RightLeftContent } from "components/RightLeftContent"
+import { LogoListing } from "./LogoListing/LogoListing.server"
 
-
-import { PartnerLogoListing } from "./PartnerLogoListing/PartnerLogoListing.server";
-import SubscribedThankYou from "./SubscribedThankYou";
-import { SearchResults } from "./SearchResults/SearchResults";
-import { FeatureBlocks } from "./FeatureBlocks";
-import { ContentPanel } from "./ContentPanel";
-import { Callout } from "./Callout";
-import { NEWFeaturedCaseStudies } from "./NEWFeaturedCaseStudies";
-import { NEWAllResources } from "./NEWAllResources/NEWAllResources";
-import { Carousel } from "./Carousel/Carousel";
-import { BestofBothWorlds2Paragraphs } from "components/BestofBothWorlds2Paragraphs/BestofBothWorlds2Paragraphs";
-import { NewPostsFeatured } from "./NewPostsFeatured";
-import PostListing from "./PostsListing/PostsListing.server";
-import { UnUsedComponent } from "./UnUsedComponent";
-import { EventListing } from "./EventListing/EventListing.server";
-import { CTABlocks } from "./CTABlocks";
-import { EventDetails } from "./EventDetails/EventDetails";
-import { StarterTemplateListing } from "./StarterTemplateListing";
-import { StarterTemplateDetails } from "./StarterTemplateDetails";
-import { ResourceDetails } from "./ResourceDetails/ResourceDetails";
-import { NEWeBookThankYou } from "./NEWeBookThankYou";
-import { VideoModule } from "./VideoModule/VideoModule";
-import { PodcastDetail } from "./Podcast/PodcastDetail";
-import { GartnerPeerInsightsBar } from "./GartnerPeerInsightsBar";
-import { ReviewRotator } from "./ReviewRotator/ReviewRotator";
-import { LatestPosts } from "./LatestPosts";
-import { GatedDownload } from "./GatedDownload/GatedDownload";
-import { LogoListingModuleCopy } from "./LogoListingModuleCopy/LogoListingModuleCopy.server";
-import { PodcastContentPanel } from "./Podcast/PodcastContentPanel";
-import { PodcastListing } from "./Podcast/PodcastListing";
-
-
-
+import { PartnerLogoListing } from "./PartnerLogoListing/PartnerLogoListing.server"
+import SubscribedThankYou from "./SubscribedThankYou"
+import { SearchResults } from "./SearchResults/SearchResults"
+import { FeatureBlocks } from "./FeatureBlocks"
+import { ContentPanel } from "./ContentPanel"
+import { Callout } from "./Callout"
+import { NEWFeaturedCaseStudies } from "./NEWFeaturedCaseStudies"
+import { NEWAllResources } from "./NEWAllResources/NEWAllResources"
+import { Carousel } from "./Carousel/Carousel"
+import { BestofBothWorlds2Paragraphs } from "components/BestofBothWorlds2Paragraphs/BestofBothWorlds2Paragraphs"
+import { NewPostsFeatured } from "./NewPostsFeatured"
+import PostListing from "./PostsListing/PostsListing.server"
+import { UnUsedComponent } from "./UnUsedComponent"
+import { EventListing } from "./EventListing/EventListing.server"
+import { CTABlocks } from "./CTABlocks"
+import { EventDetails } from "./EventDetails/EventDetails"
+import { StarterTemplateListing } from "./StarterTemplateListing"
+import { StarterTemplateDetails } from "./StarterTemplateDetails"
+import { ResourceDetails } from "./ResourceDetails/ResourceDetails"
+import { NEWeBookThankYou } from "./NEWeBookThankYou"
+import { VideoModule } from "./VideoModule/VideoModule"
+import { PodcastDetail } from "./Podcast/PodcastDetail"
+import { GartnerPeerInsightsBar } from "./GartnerPeerInsightsBar"
+import { ReviewRotator } from "./ReviewRotator/ReviewRotator"
+import { LatestPosts } from "./LatestPosts"
+import { GatedDownload } from "./GatedDownload/GatedDownload"
+import { LogoListingModuleCopy } from "./LogoListingModuleCopy/LogoListingModuleCopy.server"
+import { PodcastContentPanel } from "./Podcast/PodcastContentPanel"
+import { PodcastListing } from "./Podcast/PodcastListing"
+import { SplashImage } from "./SplashImage/SplashImage"
 
 // All of the Agility Page Module Components that are in use in this site need to be imported into this index file.
 // Place Page Modules in allModules array below, passing in a name and the component.
@@ -106,7 +103,7 @@ const allModules = [
 	{ name: "GuideLinks", module: GuideLinks },
 	{ name: "NewIntegrationModule", module: NewIntegrationModule },
 	{ name: "RightOrLeftCaseStudyTestimonial", module: RightOrLeftCaseStudyTestimonial },
-	{ name: "2BoxContent", "module": TwoBoxContent },
+	{ name: "2BoxContent", module: TwoBoxContent },
 	{ name: "G2CrowdReviewListing", module: G2CrowdReviewListing },
 	{ name: "CaseStudyListing", module: CaseStudyListing },
 	{ name: "CaseStudyContentPanel", module: CaseStudyContentPanel },
@@ -147,7 +144,7 @@ const allModules = [
 	{ name: "ResourceDetails", module: ResourceDetails },
 	{ name: "NEWeBookThankYou", module: NEWeBookThankYou },
 	{ name: "VideoModule", module: VideoModule },
-
+	{ name: "SplashImage", module: SplashImage },
 	{ name: "GartnerPeerInsightsBar", module: GartnerPeerInsightsBar },
 	{ name: "ReviewRotator", module: ReviewRotator },
 	{ name: "LatestPosts", module: LatestPosts },
@@ -156,10 +153,8 @@ const allModules = [
 	{ name: "PodcastDetail", module: PodcastDetail },
 	{ name: "PodcastContentPanel", module: PodcastContentPanel },
 	{ name: "PodcastSubscribe", module: UnUsedComponent },
-	{ name: "PodcastListing", module: PodcastListing },
-
-];
-
+	{ name: "PodcastListing", module: PodcastListing }
+]
 
 /**
  * Get the Agility Component/Module by name.
@@ -168,11 +163,8 @@ const allModules = [
  * @returns
  */
 export const getModule = (moduleName: string): any | null => {
-
-	if (!moduleName) return null;
-	const obj = allModules.find(
-		(m) => m.name.toLowerCase() === moduleName.toLowerCase()
-	);
-	if (!obj) return NoComponentFound;
+	if (!moduleName) return null
+	const obj = allModules.find((m) => m.name.toLowerCase() === moduleName.toLowerCase())
+	if (!obj) return NoComponentFound
 	return obj.module
-};
+}

--- a/styles/output.css
+++ b/styles/output.css
@@ -3283,6 +3283,11 @@ h2 {
   border-color: rgb(254 202 202 / var(--tw-border-opacity));
 }
 
+.border-red-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(248 113 113 / var(--tw-border-opacity));
+}
+
 .border-transparent {
   border-color: transparent;
 }
@@ -3310,26 +3315,6 @@ h2 {
 .border-red-500 {
   --tw-border-opacity: 1;
   border-color: rgb(239 68 68 / var(--tw-border-opacity));
-}
-
-.border-red-900 {
-  --tw-border-opacity: 1;
-  border-color: rgb(127 29 29 / var(--tw-border-opacity));
-}
-
-.border-red-700 {
-  --tw-border-opacity: 1;
-  border-color: rgb(185 28 28 / var(--tw-border-opacity));
-}
-
-.border-red-600 {
-  --tw-border-opacity: 1;
-  border-color: rgb(220 38 38 / var(--tw-border-opacity));
-}
-
-.border-red-400 {
-  --tw-border-opacity: 1;
-  border-color: rgb(248 113 113 / var(--tw-border-opacity));
 }
 
 .border-b-gray-200 {
@@ -3514,6 +3499,11 @@ h2 {
   background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }
 
+.bg-red-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 242 242 / var(--tw-bg-opacity));
+}
+
 .bg-secondary {
   --tw-bg-opacity: 1;
   background-color: rgb(255 196 20 / var(--tw-bg-opacity));
@@ -3563,11 +3553,6 @@ h2 {
 .bg-zinc-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(250 250 250 / var(--tw-bg-opacity));
-}
-
-.bg-red-50 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 242 242 / var(--tw-bg-opacity));
 }
 
 .bg-opacity-0 {


### PR DESCRIPTION
Added a new splash image component to be used by editors for a full-width splash banner img. 
[TEST URL](https://agility-website-next-js-git-dg-add-splash-image-component.publishwithagility.com/best-canadian-headless-cms?AgilityChannelID=1&lang=en-ca&agilitypreviewkey=%2b8njrinSYiOFEXvr1SdYXZ8B4P8WNLaRwQojpCY%2beeJP4U2OZlBUWyQADkWl22ipb%2bavkFT%2fkQE95I0cDRB%2f5Q%3d%3d&agilityts=20250207081644) 
