### PR TITLE
Improvement for GEO and SEO

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,33 @@
+import { getContentList } from "lib/cms/getContentList"
+import { NextResponse } from "next/server"
+
+/**
+ * Serves /llms-full.txt — a concatenated plaintext file of key site content for LLM crawlers.
+ *
+ * The content is managed in Agility CMS under the "LLMSFullText" content list.
+ * To populate it: create a content model "LLMSFullText" with a single rich-text/textblob field,
+ * then add one item containing the concatenated docs, product pages, and FAQ content you want
+ * LLMs (ChatGPT, Perplexity, Claude, Bing Copilot) to use as authoritative source material.
+ *
+ * Reference: https://llmstxt.org/
+ */
+export async function GET() {
+	const contentList = await getContentList({
+		referenceName: "LLMSFullText",
+		languageCode: "en-ca",
+		take: 1
+	})
+
+	if (!contentList || contentList.items.length === 0) {
+		return new NextResponse("Content not found", { status: 404 })
+	}
+
+	const textBlob = contentList.items[0].fields.textblob || ""
+
+	return new NextResponse(textBlob, {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+			"Cache-Control": "public, s-maxage=60, stale-while-revalidate=604800"
+		}
+	})
+}

--- a/lib/cms-content/getRichSnippet.ts
+++ b/lib/cms-content/getRichSnippet.ts
@@ -18,9 +18,47 @@ import { DateTime } from "luxon";
  * @param param0
  * @returns
  */
+const PUBLISHER = {
+	"@type": "Organization",
+	"name": "Agility CMS",
+	"logo": {
+		"@type": "ImageObject",
+		"url": "https://agilitycms.com/assets/agility-logo.svg"
+	}
+}
+
+const ORGANIZATION_SCHEMA = {
+	"@context": "https://schema.org",
+	"@type": "Organization",
+	"name": "Agility CMS",
+	"url": "https://agilitycms.com",
+	"logo": "https://agilitycms.com/assets/agility-logo.svg",
+	"foundingDate": "2003",
+	"sameAs": [
+		"https://www.linkedin.com/company/agility-cms",
+		"https://github.com/agility",
+		"https://twitter.com/AgilityCMS",
+		"https://x.com/AgilityCMS"
+	]
+}
+
+const WEBSITE_SCHEMA = {
+	"@context": "https://schema.org",
+	"@type": "WebSite",
+	"name": "Agility CMS",
+	"url": "https://agilitycms.com"
+}
+
 export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageItem }: AgilityPageProps): string | null => {
 
-	if (!dynamicPageItem) return null
+	// For the homepage, return Organization + WebSite entity schema
+	const isHomepage = sitemapNode.path === "/" || sitemapNode.path === "/home"
+	if (!dynamicPageItem) {
+		if (isHomepage) return JSON.stringify([ORGANIZATION_SCHEMA, WEBSITE_SCHEMA])
+		return null
+	}
+
+	const pageUrl = `https://agilitycms.com${sitemapNode.path}`
 
 	// *** special case for blog posts ***
 	if (dynamicPageItem.properties.definitionName === "BlogPost") {
@@ -31,7 +69,6 @@ export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageIte
 		let category = post.fields.categories?.fields.title || undefined
 		let image = post.fields.postImage?.url || undefined
 		let author = post.fields.author?.fields.title || "Agility"
-		let authorImage = post.fields.author?.fields.image?.url || undefined
 
 		let datePublished = DateTime.fromISO(post.fields.date);
 		let dateModified = DateTime.fromISO(`${post.properties.modified}`);
@@ -43,10 +80,11 @@ export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageIte
 			"@type": "BlogPosting",
 			"mainEntityOfPage": {
 				"@type": "WebPage",
-				"@id": "https://google.com/article"
+				"@id": pageUrl
 			},
 			"headline": post.fields.title,
-
+			"url": pageUrl,
+			"publisher": PUBLISHER,
 			"datePublished": datePublished.toISO(),
 			"dateModified": dateModified.toISO()
 		}
@@ -54,8 +92,7 @@ export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageIte
 		if (author) {
 			structData.author = [{
 				"@type": "Person",
-				"name": author,
-				url: authorImage
+				"name": author
 			}]
 		}
 
@@ -80,10 +117,11 @@ export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageIte
 			"@type": "Article",
 			"mainEntityOfPage": {
 				"@type": "WebPage",
-				"@id": "https://google.com/article"
+				"@id": pageUrl
 			},
 			"headline": resource.fields.title,
-
+			"url": pageUrl,
+			"publisher": PUBLISHER,
 			"datePublished": resource.fields.date,
 			"dateModified": resource.properties.modified,
 
@@ -92,8 +130,7 @@ export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageIte
 		if (resource.fields.author) {
 			structData.author = [{
 				"@type": "Person",
-				"name": resource.fields.author.fields.title,
-				url: resource.fields.author.fields.image?.url
+				"name": resource.fields.author.fields.title
 			}]
 		}
 
@@ -125,10 +162,11 @@ export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageIte
 			"@type": "Article",
 			"mainEntityOfPage": {
 				"@type": "WebPage",
-				"@id": "https://google.com/article"
+				"@id": pageUrl
 			},
 			"headline": caseStudy.fields.title,
-
+			"url": pageUrl,
+			"publisher": PUBLISHER,
 			"datePublished": caseStudy.properties.modified,
 			"dateModified": caseStudy.properties.modified,
 			image: images
@@ -147,7 +185,7 @@ export const getRichSnippet = ({ sitemapNode, page, languageCode, dynamicPageIte
 		let startTime = DateTime.fromISO(event.fields.date);
 		let endTime = startTime.plus({ hours: 1 })
 
-		let canonicalUrl = `https:/agilitycm.com/events/${event.fields.uRL}`
+		let canonicalUrl = `https://agilitycms.com/events/${event.fields.uRL}`
 		let extLink = event.fields.externalLink || canonicalUrl
 
 		let presenters = event.fields.presenters?.map(p => ({

--- a/lib/cms-content/resolveAgilityMetaData.ts
+++ b/lib/cms-content/resolveAgilityMetaData.ts
@@ -27,6 +27,7 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, sitemap, isD
 	const ogImages = (await parent).openGraph?.images || []
 	let metaTitle: string | undefined = undefined
 	let metaDescription: string | undefined = undefined
+	let articleOpenGraph: { type: "article"; publishedTime?: string; modifiedTime?: string; authors?: string[]; tags?: string[] } | undefined = undefined
 	//#region *** resolve open graph stuff from dynamic pages/layouts ***
 	if (agilityData.dynamicPageItem) {
 
@@ -54,6 +55,17 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, sitemap, isD
 						alt: post.postImage.label
 					})
 				}
+
+				const tags: string[] = post.blogTags?.map(t => t.fields.title).filter(Boolean) || []
+				if (post.categories?.fields.title) tags.unshift(post.categories.fields.title)
+
+				articleOpenGraph = {
+					type: "article",
+					publishedTime: post.date,
+					modifiedTime: `${contentItem.properties.modified}`,
+					authors: post.author ? [post.author.fields.title] : undefined,
+					tags: tags.length > 0 ? tags : undefined,
+				}
 			} else if (contentItem.properties.definitionName === "Resource") {
 				/** RESOURCE META DATA */
 				const resource = contentItem.fields as IResource
@@ -67,6 +79,13 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, sitemap, isD
 						url: `${resource.image.url}?format=auto&w=1200`,
 						alt: resource.image.label
 					})
+				}
+
+				articleOpenGraph = {
+					type: "article",
+					publishedTime: resource.date,
+					modifiedTime: `${contentItem.properties.modified}`,
+					authors: resource.author ? [resource.author.fields.title] : undefined,
 				}
 			} else if (contentItem.properties.definitionName === "CaseStudy") {
 				/** RESOURCE META DATA */
@@ -185,12 +204,18 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, sitemap, isD
 
 	}
 
+	// Normalize the path: Agility CMS stores the homepage as "/home" but the public URL is "/"
+	const pagePath = agilityData.sitemapNode.path === "/home" ? "/" : agilityData.sitemapNode.path
+
 	const metaData: Metadata = {
 		metadataBase: new URL('https://agilitycms.com'),
 		title,
 		description: metaDescription || agilityData.page?.seo?.metaDescription,
-		keywords: agilityData.page?.seo?.metaKeywords,
+		alternates: {
+			canonical: pagePath,
+		},
 		openGraph: {
+			...articleOpenGraph,
 			images: ogImages,
 		},
 

--- a/lib/cms-content/resolveAgilityMetaData.ts
+++ b/lib/cms-content/resolveAgilityMetaData.ts
@@ -205,7 +205,7 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, sitemap, isD
 	}
 
 	// Normalize the path: Agility CMS stores the homepage as "/home" but the public URL is "/"
-	const pagePath = agilityData.sitemapNode.path === "/home" ? "/" : agilityData.sitemapNode.path
+	const pagePath = `https://agilitycms.com${agilityData.sitemapNode.path === "/home" ? "/" : agilityData.sitemapNode.path}`
 
 	const metaData: Metadata = {
 		metadataBase: new URL('https://agilitycms.com'),


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1167

This is work based on a document that Nick had created on things that can improve our marketing site's SEO and GEO
[agilitycms-seo-audit-2026-04-23.pdf](https://github.com/user-attachments/files/27138431/agilitycms-seo-audit-2026-04-23.pdf). I ran this pdf by Claude and it found both code changes and non code changes that are needed to address the issues.

This PR will address the code related issues:

##### SEO: Canonical tags + article Open Graph metadata + remove deprecated keywords
`lib/cms-content/resolveAgilityMetaData.ts`
- Every page now emits <link rel="canonical"> pointing to its own clean URL (homepage /home path normalised to /). Prevents Google from picking arbitrary URL variants (UTM params, trailing slashes) as the canonical, which splits link equity.
- Blog posts and resources now emit og:type=article with article:published_time, article:modified_time, article:author, and article:tag. LinkedIn unfurls and Google Discover will now see authored, dated articles instead of generic web pages.
- Removed keywords meta tag. Google has ignored it since 2009; Bing treats it as a spam signal.

##### SEO/GEO: Fix broken JSON-LD + add Organization + WebSite schema
`lib/cms-content/getRichSnippet.ts`
- Fixed a bug present on every blog post, resource, and case study: mainEntityOfPage["@id"] was hardcoded to https://google.com/article. Now uses the actual page URL.
- Fixed Event schema URL typo: https:/agilitycm.com → https://agilitycms.com.
- Removed url: authorImage from author objects (image URL was being passed as the author's profile URL).
- Added publisher (Agility CMS Organization) to all article schemas.
- Homepage now emits Organization + WebSite JSON-LD with foundingDate, sameAs social links. This gives LLMs (ChatGPT, Perplexity, Google AI Overviews) a structured entity definition so "Agility" resolves unambiguously.

##### GEO: Add /llms-full.txt endpoint
`app/llms-full.txt/route.ts (new file)`
- Adds the endpoint at /llms-full.txt following the same CMS-driven pattern as the existing /llms.txt. Serves concatenated full content for LLM crawlers. Requires a LLMSFullText content model to be created in Agility CMS to activate.
