### PR TITLE
Improve performance for Agility website

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,16 +46,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 	return (
 		<html lang="en" className={`font-sans text-primary ${mulish.variable}`}>
 			<head>
-				<head>
-					<link rel="preconnect" href="https://static.agilitycms.com" />
-
-
-					<link rel="preconnect" href="https://js.hsforms.net" />
-					<link rel="preconnect" href="https://forms.hsforms.com" />
-					<link rel="preconnect" href="https://www.googletagmanager.com" />
-
-
-				</head>
+				<link rel="preconnect" href="https://static.agilitycms.com" />
+				<link rel="preconnect" href="https://js.hsforms.net" />
+				<link rel="preconnect" href="https://forms.hsforms.com" />
+				<link rel="preconnect" href="https://www.googletagmanager.com" />
+				<link rel="dns-prefetch" href="https://unpkg.com" />
+				<link rel="dns-prefetch" href="https://cdn.aglty.io" />
 			</head>
 			<body data-agility-guid={process.env.AGILITY_GUID}>
 				{/* GTM loaded with lazyOnload strategy to defer until after page interactive */}

--- a/components/agility-components/Carousel/Carousel.tsx
+++ b/components/agility-components/Carousel/Carousel.tsx
@@ -3,7 +3,10 @@ import { ContentItem } from "@agility/content-fetch"
 import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
 import { getContentList } from "lib/cms/getContentList"
-import { CarouselClient } from "./Carousel.client"
+import dynamic from "next/dynamic"
+
+// Dynamically imported to split embla-carousel-react out of the shared bundle
+const CarouselClient = dynamic(() => import("./Carousel.client").then(m => ({ default: m.CarouselClient })))
 
 export interface ICarouselItem {
 	title: string

--- a/components/agility-components/ROICalculator/ROICalculator.tsx
+++ b/components/agility-components/ROICalculator/ROICalculator.tsx
@@ -1,6 +1,9 @@
 import { UnloadedModuleProps, URLField } from "@agility/nextjs"
 import { getContentItem } from "lib/cms/getContentItem"
-import { ROICalculatorClient } from "./ROICalculator.client"
+import dynamic from "next/dynamic"
+
+// Dynamically imported to keep the large ROI calculator bundle off pages that don't use it
+const ROICalculatorClient = dynamic(() => import("./ROICalculator.client").then(m => ({ default: m.ROICalculatorClient })))
 
 export interface IROICalculator {
 	// Hero Section

--- a/components/agility-components/TypeFormModule/TypeFormModule.tsx
+++ b/components/agility-components/TypeFormModule/TypeFormModule.tsx
@@ -1,6 +1,9 @@
 import { UnloadedModuleProps } from "@agility/nextjs"
 import { getContentItem } from "lib/cms/getContentItem"
-import { TypeFormClient } from "./TypeFormModule.client"
+import dynamic from "next/dynamic"
+
+// Dynamically imported to split @typeform/embed-react out of the shared bundle
+const TypeFormClient = dynamic(() => import("./TypeFormModule.client").then(m => ({ default: m.TypeFormClient })))
 
 export interface ITypeFormModule {
 	form: string

--- a/components/agility-components/VideoModule/VideoModule.tsx
+++ b/components/agility-components/VideoModule/VideoModule.tsx
@@ -1,7 +1,10 @@
 import { UnloadedModuleProps, URLField } from "@agility/nextjs"
 import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
-import { VideoModuleClient } from "./VideoModule.client"
+import dynamic from "next/dynamic"
+
+// Dynamically imported to split react-player (~130 KiB) out of the shared bundle
+const VideoModuleClient = dynamic(() => import("./VideoModule.client").then(m => ({ default: m.VideoModuleClient })))
 
 interface VideoModuleFields {
 	videoPath: URLField

--- a/components/common/AgilityPic.tsx
+++ b/components/common/AgilityPic.tsx
@@ -54,7 +54,9 @@ export const AgilityPic: FC<AgilityPicProps> = ({ image, alt, priority, classNam
 	let imgHeight: number | undefined = undefined
 	let imgWidth: number | undefined = undefined
 
-	if (fallbackWidth !== undefined && fallbackWidth > 0) {
+	const isSvg = image.url.toLowerCase().endsWith(".svg")
+
+	if (!isSvg && fallbackWidth !== undefined && fallbackWidth > 0) {
 		src = `${image.url}?format=auto&w=${fallbackWidth}`
 
 		let aspectRatio = image.width / image.height
@@ -71,7 +73,7 @@ export const AgilityPic: FC<AgilityPicProps> = ({ image, alt, priority, classNam
 				let h = Number(source.height) > 0 ? `&h=${source.height}` : ``
 				const key = `${srcSet}-${index}`
 
-				if (h || w) {
+				if (!isSvg && (h || w)) {
 					//if we have a width and NOT a height, do NOT allow the image to be sized larger than the original width
 					if (w && !h) w = `&w=${Math.min(Number(source.width), image.width)}`
 
@@ -85,7 +87,15 @@ export const AgilityPic: FC<AgilityPicProps> = ({ image, alt, priority, classNam
 				return <source key={key} {...source} srcSet={srcSet} />
 			})}
 
-			<img loading={priority ? "eager" : "lazy"} src={src} alt={alt || image.label} className={className} width={imgWidth} height={imgWidth} />
+			<img
+				loading={priority ? "eager" : "lazy"}
+				fetchPriority={priority ? "high" : undefined}
+				src={src}
+				alt={alt || image.label}
+				className={className}
+				width={imgWidth}
+				height={imgHeight}
+			/>
 		</picture>
 	)
 }

--- a/components/common/header/SiteHeader.tsx
+++ b/components/common/header/SiteHeader.tsx
@@ -1,8 +1,8 @@
-/* eslint-disable @next/next/no-img-element */
 "use client"
 
-import React, { useLayoutEffect, useState } from "react"
+import React, { useEffect, useState } from "react"
 import Link from "next/link"
+import Image from "next/image"
 import classNames from "classnames"
 
 import { HeaderContent } from "lib/cms-content/getHeaderContent"
@@ -34,7 +34,7 @@ const SiteHeader = ({ headerContent: { header, links, preheaderLinks } }: Props)
 	/**
 	 * Keep track of whether the user has scrolled so we can show a shadow on the header
 	 */
-	useLayoutEffect(() => {
+	useEffect(() => {
 		const scrollHandler = (e: Event) => {
 			if (window.scrollY > 0) {
 				setIsScrolled(true)
@@ -99,12 +99,13 @@ const SiteHeader = ({ headerContent: { header, links, preheaderLinks } }: Props)
 					<div className="flex w-full items-center justify-between py-6 lg:justify-start lg:space-x-10">
 						<div className="lg:w-0 lg:flex-1">
 							<Link href="/" className="flex items-center">
-								<img
+								<Image
 									className="h-9 w-auto"
 									src={header.fields.stickyLogo.url}
 									alt={header.fields.stickyLogo.label}
-									width={header.fields.stickyLogo.height}
-									height={header.fields.stickyLogo.width}
+									width={header.fields.stickyLogo.width}
+									height={header.fields.stickyLogo.height}
+									priority
 								/>
 							</Link>
 						</div>
@@ -202,7 +203,14 @@ const SiteHeader = ({ headerContent: { header, links, preheaderLinks } }: Props)
 						<div className="flex items-center justify-between">
 							<a href="#" className="-m-1.5 p-1.5">
 								<span className="sr-only">Agility CMS</span>
-								<img alt="" src={header.fields.mobileLogo.url} className="h-8 w-auto" />
+								<Image
+									src={header.fields.mobileLogo.url}
+									alt={header.fields.mobileLogo.label || "Agility CMS"}
+									width={header.fields.mobileLogo.width}
+									height={header.fields.mobileLogo.height}
+									className="h-8 w-auto"
+									priority
+								/>
 							</a>
 							<button
 								type="button"

--- a/components/common/header/SiteHeader.tsx
+++ b/components/common/header/SiteHeader.tsx
@@ -103,8 +103,9 @@ const SiteHeader = ({ headerContent: { header, links, preheaderLinks } }: Props)
 									className="h-9 w-auto"
 									src={header.fields.stickyLogo.url}
 									alt={header.fields.stickyLogo.label}
-									width={header.fields.stickyLogo.width}
-									height={header.fields.stickyLogo.height}
+									width={header.fields.stickyLogo.width || 200}
+									height={header.fields.stickyLogo.height || 36}
+									unoptimized={header.fields.stickyLogo.url.endsWith(".svg")}
 									priority
 								/>
 							</Link>
@@ -206,8 +207,9 @@ const SiteHeader = ({ headerContent: { header, links, preheaderLinks } }: Props)
 								<Image
 									src={header.fields.mobileLogo.url}
 									alt={header.fields.mobileLogo.label || "Agility CMS"}
-									width={header.fields.mobileLogo.width}
-									height={header.fields.mobileLogo.height}
+									width={header.fields.mobileLogo.width || 200}
+									height={header.fields.mobileLogo.height || 32}
+									unoptimized={header.fields.mobileLogo.url.endsWith(".svg")}
 									className="h-8 w-auto"
 									priority
 								/>

--- a/lib/cms-content/getHeaderContent.ts
+++ b/lib/cms-content/getHeaderContent.ts
@@ -66,79 +66,42 @@ export const getHeaderContent = async ({ locale, sitemap }: Props): Promise<Head
 
 		if (!header) throw Error("No header found.")
 
+		// Phase 2: fetch menu structure and preheader links in parallel (both depend on header)
 		//expand out the menu structure with MULTIPLE CALLS so that we can purge the cache for any level :)
-		if (header?.fields.menuStructure.referencename) {
+		const [menuStructureList, preHeaderLinksList] = await Promise.all([
+			header.fields.menuStructure?.referencename
+				? getContentList({ referenceName: header.fields.menuStructure.referencename, languageCode: locale, contentLinkDepth: 0 })
+				: Promise.resolve(null),
+			header.fields.preHeaderLinks?.referencename
+				? getContentList({ referenceName: header.fields.preHeaderLinks.referencename, languageCode: locale, take: 5, contentLinkDepth: 0 })
+				: Promise.resolve(null),
+		])
 
-			const menuStructureList = await getContentList({
-				referenceName: header.fields.menuStructure.referencename,
-				languageCode: locale,
-				contentLinkDepth: 0
-			})
+		const preheaderLinks: BasicLink[] = preHeaderLinksList?.items.map((item: any) => ({
+			title: item.fields.title,
+			url: item.fields.uRL
+		})) || []
 
-			for (let i = 0; i < menuStructureList.items.length; i++) {
-				const menuItem: ContentItem<TopLevelNav> = menuStructureList.items[i]
+		// Phase 3: fetch all mega menus and sub-navs in parallel across all menu items
+		if (menuStructureList) {
+			links = await Promise.all(
+				menuStructureList.items.map(async (menuItem: ContentItem<TopLevelNav>) => {
+					const [megaMenuRes, subNavRes] = await Promise.all([
+						menuItem.fields.megaContent?.referencename
+							? getContentList({ referenceName: menuItem.fields.megaContent.referencename, languageCode: locale })
+							: Promise.resolve(null),
+						menuItem.fields.subNavigation?.referencename
+							? getContentList({ referenceName: menuItem.fields.subNavigation.referencename, languageCode: locale, contentLinkDepth: 0, take: 100 })
+							: Promise.resolve(null),
+					])
 
-				let subMenuList: ContentItem<SubLevelNav>[] | undefined = undefined
-				let megaMenuList: ContentItem<MegaMenuItem>[] | undefined = undefined
-
-				//grab the mega menu if needed
-				if (menuItem.fields.megaContent && menuItem.fields.megaContent.referencename) {
-					const res = await getContentList({
-						referenceName: menuItem.fields.megaContent.referencename,
-						languageCode: locale,
-					})
-
-					if (res && res.items && res.items.length > 0) {
-						megaMenuList = res.items
+					return {
+						menuItem,
+						megaMenuList: megaMenuRes?.items?.length ? megaMenuRes.items as ContentItem<MegaMenuItem>[] : undefined,
+						subMenuList: subNavRes?.items?.length ? subNavRes.items as ContentItem<SubLevelNav>[] : undefined,
 					}
-
-
-				}
-
-				if (menuItem.fields.subNavigation && menuItem.fields.subNavigation.referencename) {
-
-					//expand out the subnav
-					const res = await getContentList({
-						referenceName: menuItem.fields.subNavigation.referencename,
-						languageCode: locale,
-						contentLinkDepth: 0,
-						take: 100
-
-					})
-
-					if (res && res.items && res.items.length > 0) {
-						subMenuList = res.items as ContentItem<SubLevelNav>[]
-					}
-
-
-				}
-
-				links.push({
-					menuItem,
-					subMenuList,
-					megaMenuList
-
 				})
-
-			}
-		}
-
-
-		//get the preheader links
-		const preHeaderLinksRef = header.fields.preHeaderLinks
-		let preheaderLinks: BasicLink[] = []
-		if (preHeaderLinksRef && preHeaderLinksRef.referencename) {
-			const preHeaderLinksList = await getContentList({
-				referenceName: preHeaderLinksRef.referencename,
-				languageCode: locale,
-				take: 5,
-				contentLinkDepth: 0
-			})
-
-			preheaderLinks = preHeaderLinksList.items.map((item: any) => ({
-				title: item.fields.title,
-				url: item.fields.uRL
-			}))
+			)
 		}
 
 		return {

--- a/lib/cms/cacheConfig.ts
+++ b/lib/cms/cacheConfig.ts
@@ -1,11 +1,13 @@
 export const cacheConfig = {
 	/**
-	 * The default cache duration in seconds for the Agility CMS content via the fetch API
+	 * The default cache duration in seconds for the Agility CMS content via the fetch API.
+	 * Default is 3600s (1 hour) if the env var is not set.
 	 */
-	cacheDuration: process.env.AGILITY_FETCH_CACHE_DURATION ? parseInt(process.env.AGILITY_FETCH_CACHE_DURATION) : 60,
+	cacheDuration: process.env.AGILITY_FETCH_CACHE_DURATION ? parseInt(process.env.AGILITY_FETCH_CACHE_DURATION) : 3600,
 
 	/**
-	 * The duration in seconds before a path will be revalidated
+	 * The duration in seconds before a path will be revalidated via ISR.
+	 * Default is 86400s (24 hours) if the env var is not set.
 	 */
-	pathRevalidateDuration: process.env.AGILITY_PATH_REVALIDATE_DURATION ? parseInt(process.env.AGILITY_PATH_REVALIDATE_DURATION) : 60,
+	pathRevalidateDuration: process.env.AGILITY_PATH_REVALIDATE_DURATION ? parseInt(process.env.AGILITY_PATH_REVALIDATE_DURATION) : 86400,
 };


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1168

This PR will address some of the major performace issue highlighted by https://pagespeed.web.dev/analysis/https-agilitycms-com/ekawhd7373?form_factor=desktop

##### Perf: Fix invalid nested <head> + add resource hints
`app/layout.tsx`
- Removed an invalid <head> nested inside <head>. This was producing malformed HTML that browsers have to recover from during parsing, contributing to FCP delay.
- Added dns-prefetch for unpkg.com (web-studio-sdk) and cdn.aglty.io (CMS image CDN).

##### Perf: Increase ISR cache fallback defaults
`lib/cms/cacheConfig.ts`
- Changed hardcoded fallback from 60s → cacheDuration: 3600s (1h) and pathRevalidateDuration: 86400s (24h). If the environment variables are not set, pages were previously revalidating every 60 seconds, causing frequent cold ISR rebuilds and spiking TTFB for one user per minute per page. No effect if env vars are already set in production.


##### Perf: Parallelise header CMS API calls
`lib/cms-content/getHeaderContent.ts`
- The header previously made N+3 sequential await calls to Agility CMS: 1 for the header record, 1 for the menu structure, then one-at-a-time for each nav item's mega menu and sub-navigation, then 1 for preheader links. With 6–8 nav items this was ~10 sequential network round-trips on every page load, directly contributing to TTFB.
- Restructured into 3 parallel phases using Promise.all: ① fetch header, ② fetch menu structure + preheader links together, ③ fetch all sub-menus and mega-menus simultaneously. Reduces wall-clock time from ~10 serial round-trips to 3 parallel phases.

##### Perf: LCP logo + fix forced reflow
`components/common/header/SiteHeader.tsx`

- Replaced both raw <img> tags (desktop + mobile logo) with Next.js <Image priority>. Adds fetchpriority="high" and a <link rel="preload"> to <head> automatically, enables WebP/AVIF format conversion (~30–40% smaller), and eliminates the logo as a late-discovered LCP candidate.
- Fixed a pre-existing bug: desktop logo had width and height attributes swapped (.height was passed as width and vice versa).
- Changed useLayoutEffect → useEffect for the scroll shadow listener. useLayoutEffect runs synchronously before browser paint with no benefit here (the handler only reads window.scrollY, not DOM dimensions). This was the source of the unattributed 64ms forced reflow in the PageSpeed diagnostics.

##### Perf: Fix LCP fetchpriority + height bug + SVG guard
`components/common/AgilityPic.tsx`

- The priority prop previously only set loading="eager" but never fetchpriority="high". PageSpeed flagged this directly on the homepage hero image. Added fetchPriority={priority ? "high" : undefined}.
- Fixed bug: height attribute was set to imgWidth (both dimensions were the same value), giving every AgilityPic with a fallbackWidth a square intrinsic size regardless of its actual aspect ratio.
- Added SVG guard: format conversion query strings (?format=auto&w=…) are no longer appended to .svg URLs, which was silently breaking SVG images.

##### Perf: Dynamic imports to reduce unused JS on every page
`components/agility-components/VideoModule/VideoModule.tsx`
`components/agility-components/TypeFormModule/TypeFormModule.tsx`
`components/agility-components/Carousel/Carousel.tsx`
`components/agility-components/ROICalculator/ROICalculator.tsx`

- All 60+ Agility components are registered in a single index.ts, which causes webpack to bundle all component dependencies into shared chunks loaded on every page visit — even when most components aren't on that page.
- Converted the static client component imports in these four server component wrappers to next/dynamic. This splits react-player (~130 KiB), @typeform/embed-react, and embla-carousel-react into separate lazy chunks that only load on pages that actually render those modules. PageSpeed reported 116.8 KiB of unused 1st-party JS on the homepage; these changes directly address that.