### PR TITLE
Fallback for get a demo form

### DIFF
--- a/components/agility-components/GetADemo/GetADemo.client.tsx
+++ b/components/agility-components/GetADemo/GetADemo.client.tsx
@@ -2,7 +2,7 @@
 
 import Script from "next/script"
 import { posthog } from "posthog-js"
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 
 interface Props {
@@ -10,11 +10,31 @@ interface Props {
 	redirectURL?: string
 }
 
+const FormBlockedFallback = () => (
+	<p className="text-sm text-gray-600">
+		Form not loading?{" "}
+		<a
+			href="https://agilitycms.com/thank-you/get-a-demo-step-2-book"
+			target="_blank"
+			rel="noopener noreferrer"
+			className="text-highlight underline hover:text-highlight-dark"
+		>
+			Find the calendar here
+		</a>{" "}
+		to book a demo or reach out to us at{" "}
+		<a href="mailto:sales@agilitycms.com" className="text-highlight underline hover:text-highlight-dark">
+			sales@agilitycms.com
+		</a>
+		.
+	</p>
+)
+
 export const GetADemoClient = ({ hubspotForm, redirectURL }: Props) => {
 	const { portalId, formId, name } = JSON.parse(hubspotForm || '{"portalId": "", "formId": ""}')
 	const divID = `get-a-demo-form-${formId}`
 	const formLoadRef = useRef<boolean>(false)
 	const router = useRouter()
+	const [formBlocked, setFormBlocked] = useState(false)
 
 	const loadForm = useCallback(() => {
 		if (formLoadRef.current) return
@@ -32,14 +52,23 @@ export const GetADemoClient = ({ hubspotForm, redirectURL }: Props) => {
 				}
 
 				posthog.capture("website-form-submission", {
-					name: name,
+					name: name
 				})
 
 				if (redirectURL) {
 					router.push(redirectURL)
 				}
-			},
+			}
 		})
+
+		// Check after 3s whether the form actually rendered (some blockers allow
+		// the script to load but prevent the form iframe from rendering)
+		setTimeout(() => {
+			const el = document.getElementById(divID)
+			if (el && el.children.length === 0) {
+				setFormBlocked(true)
+			}
+		}, 3000)
 	}, [divID, formId, portalId, name, redirectURL, router])
 
 	useEffect(() => {
@@ -50,8 +79,13 @@ export const GetADemoClient = ({ hubspotForm, redirectURL }: Props) => {
 
 	return (
 		<>
-			<Script src="https://js.hsforms.net/forms/v2.js" async onLoad={() => loadForm()} />
-			<div id={divID}></div>
+			<Script
+				src="https://js.hsforms.net/forms/v2.js"
+				async
+				onLoad={() => loadForm()}
+				onError={() => setFormBlocked(true)}
+			/>
+			{formBlocked ? <FormBlockedFallback /> : <div id={divID}></div>}
 		</>
 	)
 }


### PR DESCRIPTION
This PR will add a fallback to the get a demo form in case hubspot form doesn't load or gets blocked by ad blocker.

There are 2 ways that this fallback will happen
1. The hubspot form fails to load
2. After a 3 second delay, check the content of the div to see if anything is there, if nothing, go to fallback.

The fallback will be a simple text that says
Form not loading? [Find the calendar here](https://agilitycms.com/thank-you/get-a-demo-step-2-book) to book a demo or reach out to us at [sales@agilitycms.com](mailto:sales@agilitycms.com).

### To test
1. Go to the preview link
2. Go to the /demo-request page
3. In your dev tool, block this network request https://js.hsforms.net/*
4. Refresh the page and you should see the fallback message