### PR TITLE
AW-63: Add Top Featured Resources component

### DIFF
--- a/components/agility-components/TopFeaturedResources/TopFeaturedResources.tsx
+++ b/components/agility-components/TopFeaturedResources/TopFeaturedResources.tsx
@@ -1,0 +1,202 @@
+import { AgilityPic, ImageField, UnloadedModuleProps } from "@agility/nextjs"
+import clsx from "clsx"
+import { ContentItem } from "@agility/content-fetch"
+import { Container } from "components/micro/Container"
+import { ThreeDashLine } from "components/micro/ThreeDashLine"
+import { LinkButton } from "components/micro/LinkButton"
+import { getContentItem } from "lib/cms/getContentItem"
+import { getContentList } from "lib/cms/getContentList"
+import { IResource } from "lib/types/IResource"
+import { IResourceType } from "lib/types/IResourceType"
+import { IEvent } from "lib/types/IEvent"
+import Link from "next/link"
+
+interface ITopFeaturedResources {
+	title?: string
+	featuredEvent?: { contentid: number }
+	resources?: {
+		referencename: string
+		sortids: string
+	}
+}
+
+interface FeaturedCard {
+	key: string
+	href: string
+	image?: ImageField
+	imageFit: "cover" | "contain"
+	isVertical: boolean
+	typeLabel: string
+	ctaText: string
+}
+
+const EBOOK_RESOURCE_TYPE_ID = 4384
+
+const isWatchType = (label: string) => /webinar|video|podcast/i.test(label)
+
+const TopFeaturedResources = async ({ module, languageCode }: UnloadedModuleProps) => {
+	const { fields, contentID } = await getContentItem<ITopFeaturedResources>({
+		contentID: module.contentid,
+		languageCode,
+		contentLinkDepth: 0
+	})
+
+	const cards: FeaturedCard[] = []
+
+	if (fields.featuredEvent?.contentid) {
+		const event = await getContentItem<IEvent>({
+			contentID: fields.featuredEvent.contentid,
+			languageCode,
+			contentLinkDepth: 1
+		})
+
+		const eventTypeTitle = event.fields.eventType?.fields?.title || "On-Demand Webinar"
+
+		cards.push({
+			key: `event-${event.contentID}`,
+			href: `/resources/events/${event.fields.uRL}`,
+			image: event.fields.mainImage,
+			imageFit: "cover",
+			isVertical: false,
+			typeLabel: eventTypeTitle,
+			ctaText: "Watch now"
+		})
+	}
+
+	if (fields.resources?.sortids) {
+		const sortIDs = fields.resources.sortids
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean)
+
+		if (sortIDs.length > 0) {
+			const filter = {
+				operator: "in" as const,
+				property: "contentID",
+				value: `"${fields.resources.sortids}"`
+			}
+
+			const res = await getContentList({
+				referenceName: fields.resources.referencename,
+				languageCode,
+				filters: [filter]
+			})
+
+			const items = (res.items as ContentItem<IResource>[]) || []
+
+			const ordered = sortIDs
+				.map((id) => items.find((it) => `${it.contentID}` === id))
+				.filter((it): it is ContentItem<IResource> => Boolean(it))
+
+			ordered.forEach((resource) => {
+				const resType = resource.fields.resourceType as ContentItem<IResourceType> | undefined
+				const typeTitle = resType?.fields?.title || ""
+				const typeSlug = typeTitle.toLowerCase().replace(/ /g, "-")
+				const href = `/resources/${typeSlug}/${resource.fields.uRL}`
+
+				const isEbook = resType?.contentID === EBOOK_RESOURCE_TYPE_ID
+				const usingBookCover = isEbook && Boolean(resource.fields.bookCover)
+				const image =
+					(isEbook ? resource.fields.bookCover : undefined) || resource.fields.image
+
+				cards.push({
+					key: `resource-${resource.contentID}`,
+					href,
+					image,
+					imageFit: usingBookCover ? "contain" : "cover",
+					isVertical: usingBookCover,
+					typeLabel: typeTitle,
+					ctaText: isWatchType(typeTitle) ? "Watch now" : "Download now"
+				})
+			})
+		}
+	}
+
+	if (cards.length === 0) return null
+
+	const title = fields.title || "Featured"
+
+	return (
+		<Container id={`agility-component-${contentID}`} data-agility-component={contentID}>
+			<div className="mx-auto max-w-7xl text-center">
+				<h2 className="text-balance text-5xl font-medium">{title}</h2>
+				<ThreeDashLine />
+
+				<div className="relative mt-10">
+					<div
+						aria-hidden
+						className="pointer-events-none absolute -left-6 -top-8 -z-10 h-40 w-32 bg-secondary md:h-48 md:w-40"
+						style={{
+							WebkitMaskImage: "url(/images/triangle-pattern.svg)",
+							maskImage: "url(/images/triangle-pattern.svg)",
+							WebkitMaskRepeat: "no-repeat",
+							maskRepeat: "no-repeat",
+							WebkitMaskSize: "contain",
+							maskSize: "contain"
+						}}
+					/>
+					<div
+						aria-hidden
+						className="pointer-events-none absolute -bottom-8 -right-6 -z-10 h-40 w-32 bg-secondary md:h-48 md:w-40"
+						style={{
+							WebkitMaskImage: "url(/images/triangle-pattern.svg)",
+							maskImage: "url(/images/triangle-pattern.svg)",
+							WebkitMaskRepeat: "no-repeat",
+							maskRepeat: "no-repeat",
+							WebkitMaskSize: "contain",
+							maskSize: "contain"
+						}}
+					/>
+
+					<div className="flex flex-col items-stretch gap-8 lg:flex-row">
+						{cards.map((card) => (
+							<div
+								key={card.key}
+								className={clsx(
+									"flex flex-col text-left",
+									card.isVertical ? "lg:flex-[1_1_0]" : "lg:flex-[2_1_0]"
+								)}
+							>
+							<Link
+								href={card.href}
+								className={clsx(
+									"group block overflow-hidden rounded-lg lg:h-64",
+									card.isVertical
+										? "h-64"
+										: "aspect-[4/3] sm:aspect-[16/9] lg:aspect-auto",
+									card.imageFit === "contain" && "bg-background/40"
+								)}
+							>
+								{card.image && (
+									<AgilityPic
+										image={card.image}
+										className={clsx(
+											"h-full w-full transition-transform duration-300 group-hover:scale-105",
+											card.imageFit === "contain" ? "object-contain p-3" : "object-cover"
+										)}
+										fallbackWidth={card.isVertical ? 320 : 640}
+									/>
+								)}
+							</Link>
+							{card.typeLabel && (
+								<h3 className="mt-5 flex-1 text-xl font-bold text-primary">
+									<Link href={card.href} className="hover:text-highlight-light">
+										{card.typeLabel}
+									</Link>
+								</h3>
+							)}
+							<div className="mt-3">
+								<LinkButton type="primary" size="sm" href={card.href}>
+									{card.ctaText}
+								</LinkButton>
+							</div>
+						</div>
+						))}
+					</div>
+				</div>
+			</div>
+		</Container>
+	)
+}
+
+export default TopFeaturedResources

--- a/components/agility-components/index.ts
+++ b/components/agility-components/index.ts
@@ -15,6 +15,7 @@ import RightORLeftContentModule from "./RightORLeftContentModule/RightORLeftCont
 import TriplePanelComparisonModule from "./TriplePanelComparisonModule"
 import RightOrLeftSteps from "./RightOrLeftSteps"
 import FeaturedResources from "./FeaturedResources"
+import TopFeaturedResources from "./TopFeaturedResources/TopFeaturedResources"
 import NewIntegrationListingModule from "./IntegrationListingModule/NewIntegrationListingModule"
 import { TwoPanelFeatureComparison } from "./TwoPanelFeatureComparison/TwoPanelFeatureComparison.server"
 import { Faqs } from "./Faqs"
@@ -109,6 +110,7 @@ const allModules = [
 	{ name: "TriplePanelComparisonModule", module: TriplePanelComparisonModule },
 	{ name: "RightOrLeftSteps", module: RightOrLeftSteps },
 	{ name: "FeaturedResources", module: FeaturedResources },
+	{ name: "TopFeaturedResources", module: TopFeaturedResources },
 	{ name: "NewIntegrationListingModule", module: NewIntegrationListingModule },
 	{ name: "TwoPanelFeatureComparison", module: TwoPanelFeatureComparison },
 	{ name: "Faqs", module: Faqs },


### PR DESCRIPTION
## Summary

Implements the **top featured-resources block** from the resources-page redesign in [AW-63](https://agilitycms.atlassian.net/browse/AW-63). Editors pick one Event (the webinar slot) and a list of Resources (Whitepaper, eBook, etc.); the component renders them in three cards under a "Featured" heading.

- **New component**: `TopFeaturedResources` (server component) — fetches the Event with `contentLinkDepth: 1` and the selected Resources via `getContentList` filtered by the picker's `sortids`, then preserves the editor's chosen order.
- **CTA logic** — Event card always says "Watch now"; resource cards say "Watch now" if the resource type matches webinar/video/podcast, otherwise "Download now".
- **eBook handling** — when `resourceType.contentID === 4384` (eBook), the card prefers the vertical `bookCover` field and renders at roughly half the width of the other cards (`lg:flex-[1_1_0]` vs `lg:flex-[2_1_0]`) using `object-contain` on a tinted background.
- **Equal heights** — flex row with `items-stretch`, image link locked to `lg:h-64`, and `flex-1` on the title pushes every CTA button to the same baseline.
- **Responsive image proportions** — landscape images use `aspect-[4/3] sm:aspect-[16/9]` on narrow screens and switch to fixed `h-64` at `lg+` so all card images line up.
- **Yellow triangle-pattern decorations** behind the cards (top-left and bottom-right) using the existing `/images/triangle-pattern.svg` as a CSS mask tinted with `bg-secondary`.

## Agility CMS

- New component model **TopFeaturedResources** (id `259`) — fields: `title` (default "Featured"), `featuredEvent` (LinkedContentDropdown → Event/`events`), `resources` (LinkedContentSearchListBox → Resource/`Resources`).
- Registered in `components/agility-components/index.ts`.

## Test plan

- [ ] Add the `TopFeaturedResources` module to a page zone in Agility, pick one Event + one Whitepaper + one eBook, and publish.
- [ ] Verify the eBook card renders narrower than the other two and uses the vertical `bookCover` image.
- [ ] Verify all three cards line up at the same height with the CTA buttons aligned at the bottom.
- [ ] Verify the yellow triangle pattern shows behind the cards on top-left and bottom-right.
- [ ] Resize the browser narrower — landscape card images should scale proportionally; on `lg+` all images should hit the same fixed height.
- [ ] Click each card image, title, and CTA button — all should route to the correct `/resources/{type}/{slug}` (or `/resources/events/{slug}` for the event).
- [ ] Render with only an Event selected (no resources) and only resources selected (no event) — both should still render the cards that exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AW-63]: https://agilitycms.atlassian.net/browse/AW-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ