### PR TITLE
Improve AgilityCMS core vitals

### DIFF
--- a/components/agility-components/CustomerResults/CustomerResults.tsx
+++ b/components/agility-components/CustomerResults/CustomerResults.tsx
@@ -60,6 +60,7 @@ export const CustomerResults = async ({ module, languageCode }: UnloadedModulePr
 										src={logoSrc}
 										alt={logo.label || ""}
 										className="h-20 w-auto"
+										height="80"
 										loading="lazy"
 									/>
 								) : (

--- a/components/agility-components/FeatureBlocks.tsx
+++ b/components/agility-components/FeatureBlocks.tsx
@@ -99,7 +99,7 @@ export const FeatureBlocks = async ({ module, languageCode }: UnloadedModuleProp
 									className="flex flex-col items-center gap-4 border border-background p-6 pt-7 shadow-md transition-all hover:shadow-lg"
 								>
 									{/* these are always SVGs, so no need to formatting */}
-									<img className="w-28" src={feature.fields.icon.url} alt={feature.fields.icon.label} />
+									<img className="w-28" src={feature.fields.icon.url} alt={feature.fields.icon.label} width="112" height="112" />
 									<h2 className="text-lg font-medium">{feature.fields.title}</h2>
 									<h3>{feature.fields.subtitle}</h3>
 									<p className="flex-1">{feature.fields.textBlob}</p>
@@ -112,7 +112,7 @@ export const FeatureBlocks = async ({ module, languageCode }: UnloadedModuleProp
 									className="flex flex-col items-center gap-4 border border-background p-6 pt-7 shadow-md transition-all hover:shadow-lg"
 								>
 									{/* these are always SVGs, so no need to formatting */}
-									<img className="w-28" src={feature.fields.icon.url} alt={feature.fields.icon.label} />
+									<img className="w-28" src={feature.fields.icon.url} alt={feature.fields.icon.label} width="112" height="112" />
 									<h2 className="text-lg font-medium">{feature.fields.title}</h2>
 									<h3>{feature.fields.subtitle}</h3>
 									<p className="flex-1">{feature.fields.textBlob}</p>

--- a/components/agility-components/G2CrowdReviewListing/G2CrowdReviewListing.client.tsx
+++ b/components/agility-components/G2CrowdReviewListing/G2CrowdReviewListing.client.tsx
@@ -32,6 +32,7 @@ export const G2CrowdReviewListingClient = ({
 			<div ref={cRef} className="mt-10"></div>
 			<Script
 				src="https://www.gartner.com/reviews/public/Widget/js/widget.js"
+				strategy="lazyOnload"
 				onLoad={() => {
 					setTimeout(() => {
 						loadGarterWidget()

--- a/components/agility-components/GatedDownload/GatedDownload.client.tsx
+++ b/components/agility-components/GatedDownload/GatedDownload.client.tsx
@@ -71,7 +71,7 @@ export const GatedDownloadClient = ({ hubspotForm, redirectURL }: IGatedDownload
 	return (
 		<>
 			<Script src={`https://js.hsforms.net/forms/v2.js`} async onLoad={() => loadForm()} />
-			<div id={divID}></div>
+			<div id={divID} className="min-h-[400px]"></div>
 		</>
 	)
 }

--- a/components/agility-components/GetADemo/GetADemo.client.tsx
+++ b/components/agility-components/GetADemo/GetADemo.client.tsx
@@ -11,22 +11,24 @@ interface Props {
 }
 
 const FormBlockedFallback = () => (
-	<p className="text-sm text-gray-600">
-		Form not loading?{" "}
-		<a
-			href="https://agilitycms.com/thank-you/get-a-demo-step-2-book"
-			target="_blank"
-			rel="noopener noreferrer"
-			className="text-highlight underline hover:text-highlight-dark"
-		>
-			Find the calendar here
-		</a>{" "}
-		to book a demo or reach out to us at{" "}
-		<a href="mailto:sales@agilitycms.com" className="text-highlight underline hover:text-highlight-dark">
-			sales@agilitycms.com
-		</a>
-		.
-	</p>
+	<div className="min-h-[400px]">
+		<p className="text-sm text-gray-600">
+			Form not loading?{" "}
+			<a
+				href="https://agilitycms.com/thank-you/get-a-demo-step-2-book"
+				target="_blank"
+				rel="noopener noreferrer"
+				className="text-highlight underline hover:text-highlight-dark"
+			>
+				Find the calendar here
+			</a>{" "}
+			to book a demo or reach out to us at{" "}
+			<a href="mailto:sales@agilitycms.com" className="text-highlight underline hover:text-highlight-dark">
+				sales@agilitycms.com
+			</a>
+			.
+		</p>
+	</div>
 )
 
 export const GetADemoClient = ({ hubspotForm, redirectURL }: Props) => {
@@ -85,7 +87,7 @@ export const GetADemoClient = ({ hubspotForm, redirectURL }: Props) => {
 				onLoad={() => loadForm()}
 				onError={() => setFormBlocked(true)}
 			/>
-			{formBlocked ? <FormBlockedFallback /> : <div id={divID}></div>}
+			{formBlocked ? <FormBlockedFallback /> : <div id={divID} className="min-h-[400px]"></div>}
 		</>
 	)
 }

--- a/components/agility-components/Hero/Hero.tsx
+++ b/components/agility-components/Hero/Hero.tsx
@@ -24,8 +24,15 @@ export const Hero = async ({ module, languageCode }: UnloadedModuleProps) => {
 	})
 
 	return (
-
-
+		<>
+		{fields.mediaType === "image" && fields.image && (
+			<link
+				rel="preload"
+				as="image"
+				href={`${fields.image.url}?format=auto&w=480`}
+				fetchPriority="high"
+			/>
+		)}
 		<Container className="text-balance text-center">
 			<div className="mx-auto max-w-7xl">
 				{fields.mediaType === "video" && fields.videoURL && (
@@ -36,7 +43,7 @@ export const Hero = async ({ module, languageCode }: UnloadedModuleProps) => {
 
 				{fields.mediaType === "image" && fields.image && (
 					<div className="mb-10 flex w-full justify-center">
-						<AgilityPic image={fields.image} fallbackWidth={480} />
+						<AgilityPic image={fields.image} fallbackWidth={480} priority />
 					</div>
 				)}
 
@@ -58,6 +65,6 @@ export const Hero = async ({ module, languageCode }: UnloadedModuleProps) => {
 				)}
 			</div>
 		</Container>
-
+		</>
 	)
 }

--- a/components/agility-components/LogoListingModule/LogoListingModule.client.tsx
+++ b/components/agility-components/LogoListingModule/LogoListingModule.client.tsx
@@ -34,6 +34,7 @@ export const LogoListingModuleClient = ({ logos }: Props) => {
 										src={src}
 										alt={logo.title}
 										className="w-full"
+										height="64"
 										loading="lazy"
 									/>
 								</div>

--- a/components/agility-components/NEWAllResources/ResourceListingItem.tsx
+++ b/components/agility-components/NEWAllResources/ResourceListingItem.tsx
@@ -23,10 +23,10 @@ export const ResourceListingItem = ({ item, index, size }: Props) => {
 			href={url}
 			key={item.contentID}
 		>
-			<div className="relative h-52 w-full overflow-clip">
+			<div className="relative h-52 w-full overflow-clip [&_picture]:block [&_picture]:h-full [&_picture]:w-full">
 				<AgilityPic
 					image={item.fields.image}
-					className="w-full object-cover object-center transition-transform group-hover:scale-110"
+					className="h-full w-full object-cover object-center transition-transform group-hover:scale-110"
 					fallbackWidth={480}
 					sources={[
 						//screen at least than 1280, it's 1/3 of the screen

--- a/components/agility-components/PartnerLogoListing/PartnerLogoListing.client.tsx
+++ b/components/agility-components/PartnerLogoListing/PartnerLogoListing.client.tsx
@@ -34,7 +34,7 @@ export const PartnerLogoListingClient = ({ logos }: Props) => {
 							<div className="embla__slide flex items-center justify-center" key={index}>
 								<div className="my-3">
 									{/* eslint-disable-next-line @next/next/no-img-element */}
-									<img src={src} alt={logo.title} className="h-16 w-auto" />
+									<img src={src} alt={logo.title} className="h-16 w-auto" height="64" />
 								</div>
 							</div>
 						)
@@ -43,37 +43,4 @@ export const PartnerLogoListingClient = ({ logos }: Props) => {
 			</div>
 		</div>
 	)
-
-	// return (
-	// 	<>
-	// 		{/* @ts-ignore */}
-	// 		<Slider {...settings} className="">
-	// 			{logos.map((logo, index) => {
-	// 				let src = `${logo.logo.url}?format=auto&h=128`
-	// 				if (logo.logo.url.endsWith(".svg")) src = logo.logo.url
-
-	// 				return (
-	// 					<Fragment key={index}>
-	// 						{logo.uRL ? (
-	// 							<Link
-	// 								href={logo.uRL.href}
-	// 								target={logo.uRL.target}
-	// 								title={logo.uRL.text || logo.title}
-	// 								className="my-3 block px-4"
-	// 							>
-	// 								{/* eslint-disable-next-line @next/next/no-img-element */}
-	// 								<img src={src} alt={logo.logo.label || logo.title} className="h-16 w-auto" />
-	// 							</Link>
-	// 						) : (
-	// 							<div className="my-3 px-4">
-	// 								{/* eslint-disable-next-line @next/next/no-img-element */}
-	// 								<img src={src} alt={logo.title} className="h-16 w-auto" />
-	// 							</div>
-	// 						)}
-	// 					</Fragment>
-	// 				)
-	// 			})}
-	// 		</Slider>
-	// 	</>
-	// )
 }

--- a/components/agility-components/PostDetails.tsx
+++ b/components/agility-components/PostDetails.tsx
@@ -76,6 +76,17 @@ const PostDetails = async ({ dynamicPageItem }: UnloadedModuleProps) => {
 	const dateStr = DateTime.fromJSDate(new Date(post.date)).toFormat("LLL. dd, yyyy")
 
 	return (
+		<>
+		{/* Hoist a preload hint for the hero image so the browser fetches it before
+		    parsing down to the <picture> element — the primary LCP fix for /blog/* */}
+		{post.postImage && (
+			<link
+				rel="preload"
+				as="image"
+				href={`${post.postImage.url}?format=auto&w=800`}
+				fetchPriority="high"
+			/>
+		)}
 		<Container >
 			<article className="mx-auto max-w-7xl">
 				<time className="text-slate-600">{dateStr}</time>
@@ -102,7 +113,7 @@ const PostDetails = async ({ dynamicPageItem }: UnloadedModuleProps) => {
 							<AgilityPic
 								image={post.postImage}
 								alt={post.title}
-								fallbackWidth={400}
+								fallbackWidth={800}
 								priority
 								className="w-full"
 								sources={[
@@ -254,6 +265,7 @@ const PostDetails = async ({ dynamicPageItem }: UnloadedModuleProps) => {
 				</div> */}
 			</article>
 		</Container>
+		</>
 	)
 }
 

--- a/components/agility-components/Pricing/PricingPackagesModule.client.tsx
+++ b/components/agility-components/Pricing/PricingPackagesModule.client.tsx
@@ -188,7 +188,7 @@ export const PricingPackagesModuleClient = ({
 
 								{/* descriptions */}
 								<div className="flex flex-1 flex-col">
-									<div className="min-h-[162pxX]">
+									<div className="min-h-[162px]">
 										<h3 className="text-4xl font-bold">{packageItem?.fields?.cost}</h3>
 										<div className="text-sm mt-2">{packageItem?.fields?.pricingPlan}</div>
 

--- a/components/agility-components/ResourceDetails/DownloadForm.client.tsx
+++ b/components/agility-components/ResourceDetails/DownloadForm.client.tsx
@@ -61,7 +61,7 @@ export const DownloadForm = ({ hubspotForm, redirectURL }: IDownloadForm) => {
 
 			<div className="relative">
 				<div className="relative z-[2] border-t-2 border-t-highlight-light bg-white p-6 shadow-lg">
-					<div id={divID}></div>
+					<div id={divID} className="min-h-[400px]"></div>
 				</div>
 				<img
 					src="https://static.agilitycms.com/layout/static/triangle-pattern.svg"

--- a/components/agility-components/SubmissionForm/SubmissionForm.client.tsx
+++ b/components/agility-components/SubmissionForm/SubmissionForm.client.tsx
@@ -63,7 +63,7 @@ export const SubmissionFormClient = ({
 					<div className="flex flex-col gap-10 md:flex-row">
 						<div className="width-1/2 relative flex-1">
 							<div className="relative z-[2] border-t-2 border-t-highlight-light bg-white p-6 shadow-lg">
-								<div id={divID}></div>
+								<div id={divID} className="min-h-[400px]"></div>
 							</div>
 							<img
 								src="https://static.agilitycms.com/layout/static/triangle-pattern.svg"

--- a/components/agility-components/TriplePanelComparisonModule.tsx
+++ b/components/agility-components/TriplePanelComparisonModule.tsx
@@ -49,9 +49,9 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 					{fields.panel1Graphic && fields.panel1Title && (
 						<div className="flex flex-col gap-4">
 							{fields.panel1Graphic.url.endsWith(".svg") ? (
-								<img src={fields.panel1Graphic.url} alt={fields.panel1Graphic.label} className="w-16" />
+								<img src={fields.panel1Graphic.url} alt={fields.panel1Graphic.label} className="w-16" width="64" height="64" />
 							) : (
-								<AgilityPic image={fields.panel1Graphic} className="w-16" />
+								<AgilityPic image={fields.panel1Graphic} className="w-16" fallbackWidth={64} />
 							)}
 							<h3 className="text-lg font-medium">{fields.panel1Title}</h3>
 							{fields.panel1CheckedContent && (
@@ -75,9 +75,9 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 					{fields.panel2Graphic && fields.panel2Title && (
 						<div className="flex flex-col gap-4">
 							{fields.panel2Graphic.url.endsWith(".svg") ? (
-								<img src={fields.panel2Graphic.url} alt={fields.panel2Graphic.label} className="w-16" />
+								<img src={fields.panel2Graphic.url} alt={fields.panel2Graphic.label} className="w-16" width="64" height="64" />
 							) : (
-								<AgilityPic image={fields.panel2Graphic} className="w-16" />
+								<AgilityPic image={fields.panel2Graphic} className="w-16" fallbackWidth={64} />
 							)}
 							<h3 className="text-lg font-medium">{fields.panel2Title}</h3>
 							{fields.panel2CheckedContent && (
@@ -101,9 +101,9 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 					{fields.panel3Graphic && fields.panel3Title && (
 						<div className="flex flex-col gap-4">
 							{fields.panel3Graphic.url.endsWith(".svg") ? (
-								<img src={fields.panel3Graphic.url} alt={fields.panel3Graphic.label} className="w-16" />
+								<img src={fields.panel3Graphic.url} alt={fields.panel3Graphic.label} className="w-16" width="64" height="64" />
 							) : (
-								<AgilityPic image={fields.panel3Graphic} className="w-16" />
+								<AgilityPic image={fields.panel3Graphic} className="w-16" fallbackWidth={64} />
 							)}
 							<h3 className="text-lg font-medium">{fields.panel3Title}</h3>
 							{fields.panel3CheckedContent && (

--- a/components/agility-components/TrustedByLogos/TrustedByLogos.tsx
+++ b/components/agility-components/TrustedByLogos/TrustedByLogos.tsx
@@ -56,6 +56,7 @@ export const TrustedByLogos = async ({ module, languageCode }: UnloadedModulePro
 								src={src}
 								alt={name || logo.label || ""}
 								className="h-20 w-auto lg:h-24"
+								height="80"
 								loading="lazy"
 							/>
 						)

--- a/components/common/AgilityPic.tsx
+++ b/components/common/AgilityPic.tsx
@@ -58,11 +58,12 @@ export const AgilityPic: FC<AgilityPicProps> = ({ image, alt, priority, classNam
 
 	if (!isSvg && fallbackWidth !== undefined && fallbackWidth > 0) {
 		src = `${image.url}?format=auto&w=${fallbackWidth}`
+	}
 
-		let aspectRatio = image.width / image.height
+	// Set width/height for both raster and SVG when CMS has stored dimensions
+	if (fallbackWidth !== undefined && fallbackWidth > 0 && image.width > 0 && image.height > 0) {
 		imgWidth = fallbackWidth
-		imgHeight = Math.round(fallbackWidth / aspectRatio)
-
+		imgHeight = Math.round(fallbackWidth / (image.width / image.height))
 	}
 
 	return (
@@ -91,7 +92,7 @@ export const AgilityPic: FC<AgilityPicProps> = ({ image, alt, priority, classNam
 				loading={priority ? "eager" : "lazy"}
 				fetchPriority={priority ? "high" : undefined}
 				src={src}
-				alt={alt || image.label}
+				alt={alt ?? image.label ?? ""}
 				className={className}
 				width={imgWidth}
 				height={imgHeight}


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1314

In this PR we are tackling 3 categories of core web vitals for our marketing webstie and also 1 layout issue with the resources page.

### LCP — Largest Contentful Paint
1. **PostDetails.tsx**
Added <link rel="preload" as="image"> with fetchpriority="high" in `<head>` for the blog hero image. Browser fetches it before parsing the body — primary fix for the 241 blog URLs flagged in Search Console. Also bumped fallback `<img>` width from w=400 → w=800 to correct the intrinsic size mismatch on desktop.

2. **Hero.tsx**
Added priority to AgilityPic (was lazy-loading an above-the-fold image) and a matching `<link rel="preload">` hint for the exact fallback URL so no unused-preload warning is triggered.

### INP — Interaction to Next Paint
1. **G2CrowdReviewListing.client.tsx**
Added strategy="lazyOnload" to the Gartner widget `<Script>`. No strategy defaulted to afterInteractive, blocking the main thread during page load. lazyOnload defers it until the browser is fully idle.

### CLS — Cumulative Layout Shift
HubSpot form containers (4 components) — All four had `<div id={divID}></div>` starting at 0px height, shifting content when HubSpot injected the iframe. Fixed with min-h-[400px] to pre-reserve space:

1. GetADemo.client.tsx
2. GatedDownload.client.tsx
3. SubmissionForm.client.tsx
4. DownloadForm.client.tsx


**PricingPackagesModule.client.tsx**
Fixed typo min-h-[162pxX] → min-h-[162px]. Trailing X made Tailwind silently ignore the class, leaving pricing card description areas with no reserved height.

**TriplePanelComparisonModule.tsx**
Added width="64" height="64" to SVG panel graphic `<img>` tags and fallbackWidth={64} to non-SVG AgilityPic calls. Without declared dimensions the browser couldn't reserve space before icons loaded.

**FeatureBlocks.tsx**
Added width="112" height="112" to SVG feature icon `<img>` tags (matching the w-28 = 112px CSS class).

**CustomerResults.tsx**
Added height="80" to customer logo images (matching h-20 = 80px CSS).

**PartnerLogoListing.client.tsx**
Added height="64" to partner logo carousel images (matching h-16 = 64px CSS).

**TrustedByLogos.tsx**
Added height="80" to logo <img> tags (matching h-20 = 80px CSS) so the browser reserves vertical space before logos load.

**LogoListingModule.client.tsx**
Added height="64" to carousel logo images as a baseline dimension for CLS prevention.

### Accessibility — image-alt / unsized-images
**AgilityPic.tsx**
Two fixes to this shared component used site-wide:

1. Dimension guard: Added image.width > 0 && image.height > 0 check before computing aspect ratio. Previously, images with no stored CMS dimensions produced NaN/Infinity which React dropped, leaving the `<img>` unsized. Now width/height are only set when the aspect ratio is computable.
2. Alt text fallback: Changed alt || image.label to alt ?? image.label ?? "". The || operator treated an empty string label as falsy and dropped the alt attribute entirely. ?? only falls through on null/undefined, and the final ?? "" ensures the attribute is always present in the DOM even for unlabelled images.
