### PR TITLE
AW-86: Add hideLegend option to ComparisonTable

### DIFF
--- a/components/agility-components/ComparisonTable/ComparisonTable.client.tsx
+++ b/components/agility-components/ComparisonTable/ComparisonTable.client.tsx
@@ -12,16 +12,17 @@ export interface Platform {
 export type ComparisonRow =
 	| { type: "category"; label: string }
 	| {
-			type: "feature"
-			name: string
-			tooltip?: string
-			cells: Record<string, { status: "full" | "partial" | "none"; text?: string }>
-	  }
+		type: "feature"
+		name: string
+		tooltip?: string
+		cells: Record<string, { status: "full" | "partial" | "none"; text?: string }>
+	}
 
 interface Props {
 	platforms: Platform[]
 	rows: ComparisonRow[]
 	footnote?: string
+	hideLegend: boolean
 }
 
 function StatusCell({ status, text }: { status: "full" | "partial" | "none"; text?: string }) {
@@ -58,7 +59,7 @@ function StatusCell({ status, text }: { status: "full" | "partial" | "none"; tex
 	)
 }
 
-export function ComparisonTableClient({ platforms, rows, footnote }: Props) {
+export function ComparisonTableClient({ platforms, rows, footnote, hideLegend }: Props) {
 	const [openTooltip, setOpenTooltip] = useState<string | null>(null)
 	const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
 	const tableRef = useRef<HTMLDivElement>(null)
@@ -90,26 +91,28 @@ export function ComparisonTableClient({ platforms, rows, footnote }: Props) {
 	return (
 		<div ref={tableRef}>
 			{/* Legend */}
-			<div className="mb-6 flex flex-wrap items-center justify-center gap-6 text-sm text-gray-600">
-				<div className="flex items-center gap-2">
-					<span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-50">
-						<IconCheck className="h-3 w-3 text-green-600" stroke={3} />
-					</span>
-					<span>Fully supported</span>
+			{!hideLegend && (
+				<div className="mb-6 flex flex-wrap items-center justify-center gap-6 text-sm text-gray-600">
+					<div className="flex items-center gap-2">
+						<span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-50">
+							<IconCheck className="h-3 w-3 text-green-600" stroke={3} />
+						</span>
+						<span>Fully supported</span>
+					</div>
+					<div className="flex items-center gap-2">
+						<span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-50">
+							<IconMinus className="h-3 w-3 text-amber-500" stroke={3} />
+						</span>
+						<span>Partial / add-on / plugin required</span>
+					</div>
+					<div className="flex items-center gap-2">
+						<span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-50">
+							<IconX className="h-3 w-3 text-red-400" stroke={3} />
+						</span>
+						<span>Not available</span>
+					</div>
 				</div>
-				<div className="flex items-center gap-2">
-					<span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-50">
-						<IconMinus className="h-3 w-3 text-amber-500" stroke={3} />
-					</span>
-					<span>Partial / add-on / plugin required</span>
-				</div>
-				<div className="flex items-center gap-2">
-					<span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-50">
-						<IconX className="h-3 w-3 text-red-400" stroke={3} />
-					</span>
-					<span>Not available</span>
-				</div>
-			</div>
+			)}
 
 			{/* Table */}
 			<div className="mx-auto max-w-6xl overflow-x-auto rounded-2xl border border-gray-200/40 bg-white shadow-lg">

--- a/components/agility-components/ComparisonTable/ComparisonTable.tsx
+++ b/components/agility-components/ComparisonTable/ComparisonTable.tsx
@@ -37,6 +37,7 @@ interface IComparisonTable {
 	anchorId?: string
 	comparisonData?: string
 	footnote?: string
+	hideLegend?: string
 }
 
 interface ParsedData {
@@ -109,7 +110,7 @@ function parseComparisonData(raw: string): ParsedData | null {
 }
 
 export const ComparisonTable = async ({ module, languageCode }: UnloadedModuleProps) => {
-	const { fields, contentID } = await getContentItem<IComparisonTable>({
+	const { fields, contentID, properties } = await getContentItem<IComparisonTable>({
 		contentID: module.contentid,
 		languageCode,
 		contentLinkDepth: 0,
@@ -202,6 +203,7 @@ export const ComparisonTable = async ({ module, languageCode }: UnloadedModulePr
 					platforms={platformList}
 					rows={rows}
 					footnote={fields.footnote}
+					hideLegend={fields.hideLegend == "true"}
 				/>
 			</div>
 		</Container>

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,7 +11,7 @@ export async function middleware(request: NextRequest) {
 	const host = request.nextUrl.host
 	const pathAndQuery = request.nextUrl.pathname + request.nextUrl.search
 
-	if (host !== "localhost:3000" //local
+	if (!host.startsWith("localhost:") //local (any port)
 		&& !host.endsWith("netlify.app") //netlify
 		&& !host.endsWith("publishwithagility.com") //vercel
 		&& !host.endsWith("agilitycms.com")) //prod

--- a/styles/output.css
+++ b/styles/output.css
@@ -332,6 +332,9 @@
   .-top-7 {
     top: calc(var(--spacing) * -7);
   }
+  .-top-8 {
+    top: calc(var(--spacing) * -8);
+  }
   .-top-12 {
     top: calc(var(--spacing) * -12);
   }
@@ -368,6 +371,9 @@
   .-right-1\/4 {
     right: calc(calc(1/4 * 100%) * -1);
   }
+  .-right-6 {
+    right: calc(var(--spacing) * -6);
+  }
   .-right-10 {
     right: calc(var(--spacing) * -10);
   }
@@ -392,6 +398,9 @@
   .right-5 {
     right: calc(var(--spacing) * 5);
   }
+  .-bottom-8 {
+    bottom: calc(var(--spacing) * -8);
+  }
   .-bottom-10 {
     bottom: calc(var(--spacing) * -10);
   }
@@ -412,6 +421,9 @@
   }
   .bottom-5 {
     bottom: calc(var(--spacing) * 5);
+  }
+  .-left-6 {
+    left: calc(var(--spacing) * -6);
   }
   .-left-7 {
     left: calc(var(--spacing) * -7);
@@ -1785,6 +1797,9 @@
   .table {
     display: table;
   }
+  .aspect-\[4\/3\] {
+    aspect-ratio: 4/3;
+  }
   .aspect-video {
     aspect-ratio: var(--aspect-video);
   }
@@ -2290,6 +2305,9 @@
   .items-start {
     align-items: flex-start;
   }
+  .items-stretch {
+    align-items: stretch;
+  }
   .justify-between {
     justify-content: space-between;
   }
@@ -2785,12 +2803,6 @@
     background-color: color-mix(in srgb, oklch(21% 0.034 264.665) 40%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-gray-900) 40%, transparent);
-    }
-  }
-  .bg-gray-900\/60 {
-    background-color: color-mix(in srgb, oklch(21% 0.034 264.665) 60%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-gray-900) 60%, transparent);
     }
   }
   .bg-green-50 {
@@ -4018,14 +4030,6 @@
       }
     }
   }
-  .group-hover\:grayscale-0 {
-    &:is(:where(.group):hover *) {
-      @media (hover: hover) {
-        --tw-grayscale: grayscale(0%);
-        filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-      }
-    }
-  }
   .group-aria-selected\:text-highlight-dark {
     &:is(:where(.group)[aria-selected="true"] *) {
       color: var(--color-highlight-dark);
@@ -4946,6 +4950,11 @@
       display: flex;
     }
   }
+  .sm\:aspect-\[16\/9\] {
+    @media (width >= 40rem) {
+      aspect-ratio: 16/9;
+    }
+  }
   .sm\:min-h-\[3em\] {
     @media (width >= 40rem) {
       min-height: 3em;
@@ -5594,6 +5603,11 @@
       height: calc(var(--spacing) * 8);
     }
   }
+  .md\:h-48 {
+    @media (width >= 48rem) {
+      height: calc(var(--spacing) * 48);
+    }
+  }
   .md\:h-full {
     @media (width >= 48rem) {
       height: 100%;
@@ -5637,6 +5651,11 @@
   .md\:w-32 {
     @media (width >= 48rem) {
       width: calc(var(--spacing) * 32);
+    }
+  }
+  .md\:w-40 {
+    @media (width >= 48rem) {
+      width: calc(var(--spacing) * 40);
     }
   }
   .md\:w-\[400px\] {
@@ -6367,6 +6386,11 @@
       display: none;
     }
   }
+  .lg\:aspect-auto {
+    @media (width >= 64rem) {
+      aspect-ratio: auto;
+    }
+  }
   .lg\:h-12 {
     @media (width >= 64rem) {
       height: calc(var(--spacing) * 12);
@@ -6380,6 +6404,11 @@
   .lg\:h-36 {
     @media (width >= 64rem) {
       height: calc(var(--spacing) * 36);
+    }
+  }
+  .lg\:h-64 {
+    @media (width >= 64rem) {
+      height: calc(var(--spacing) * 64);
     }
   }
   .lg\:h-\[450px\] {
@@ -6465,6 +6494,16 @@
   .lg\:flex-1 {
     @media (width >= 64rem) {
       flex: 1;
+    }
+  }
+  .lg\:flex-\[1_1_0\] {
+    @media (width >= 64rem) {
+      flex: 1 1 0;
+    }
+  }
+  .lg\:flex-\[2_1_0\] {
+    @media (width >= 64rem) {
+      flex: 2 1 0;
     }
   }
   .lg\:origin-center {


### PR DESCRIPTION
## Summary
- Adds a `hideLegend` field to the `ComparisonTable` component so editors can render a variant without the icon callout legend (AW-86).
- Loosens the middleware localhost host check to allow any port (e.g. `localhost:3001`), not just `3000`.

JIRA: [AW-86](https://agilitycms.atlassian.net/browse/AW-86)

## Test plan
- [x] Verify ComparisonTable renders with legend when `hideLegend` is unset / false
- [x] Verify ComparisonTable renders without the legend when `hideLegend` is `true`
- [x] Confirm dev server on a non-3000 port (e.g. 3001) no longer 301-redirects to agilitycms.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AW-86]: https://agilitycms.atlassian.net/browse/AW-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ