### PR TITLE
perf: defer non-essential JS from First Load

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -74,11 +74,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 					)}
 
 					<HubspotTracker />
-					{/* Load in the agility web-studio-sdk script - deferred to reduce blocking */}
-					<Script 
-						src="https://unpkg.com/@agility/web-studio-sdk@latest/dist/index.js" 
-						strategy="lazyOnload"
-					/>
+					{/* Load in the agility web-studio-sdk script - only in preview/dev (CMS editing context) */}
+					{(isPreview || isDevelopmentMode) && (
+						<Script
+							src="https://unpkg.com/@agility/web-studio-sdk@latest/dist/index.js"
+							strategy="lazyOnload"
+						/>
+					)}
 				</PostHogProvider>
 			</body>
 		</html>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,32 +1,13 @@
 // app/providers.tsx
 "use client"
 
-import posthog from "posthog-js"
-import { PostHogProvider as PHProvider } from "posthog-js/react"
 import { useEffect } from "react"
+import { initPostHog } from "lib/analytics/posthog"
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
 	useEffect(() => {
-		const timer = setTimeout(() => {
-			if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
-				posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-					api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-					defaults: "2025-05-24",
-					before_send: (event) => {
-						const exceptionList = event?.properties?.["$exception_list"]
-						if (
-							Array.isArray(exceptionList) &&
-							exceptionList.some((e: any) => e?.value?.includes("ResizeObserver loop"))
-						) {
-							return null
-						}
-						return event
-					}
-				})
-			}
-		}, 1000)
-		return () => clearTimeout(timer)
+		initPostHog()
 	}, [])
 
-	return <PHProvider client={posthog}>{children}</PHProvider>
+	return <>{children}</>
 }

--- a/components/agility-components/GatedDownload/GatedDownload.client.tsx
+++ b/components/agility-components/GatedDownload/GatedDownload.client.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 "use client"
 import Script from "next/script"
-import { posthog } from "posthog-js"
+import { capture, identify } from "lib/analytics/posthog"
 import { useCallback, useEffect, useRef } from "react"
 
 import { useRouter } from 'next/navigation'
@@ -49,10 +49,10 @@ export const GatedDownloadClient = ({ hubspotForm, redirectURL }: IGatedDownload
 				console.log("Form submitted successfully:", hsForm.name)
 				const emailAddress = data?.submissionValues?.email
 				if (emailAddress) {
-					posthog.identify(emailAddress);
+					identify(emailAddress);
 				}
 
-				posthog.capture('website-form-submission', {
+				capture('website-form-submission', {
 					name: hsForm.name
 				});
 

--- a/components/agility-components/GetADemo/GetADemo.client.tsx
+++ b/components/agility-components/GetADemo/GetADemo.client.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Script from "next/script"
-import { posthog } from "posthog-js"
+import { capture, identify } from "lib/analytics/posthog"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 
@@ -50,10 +50,10 @@ export const GetADemoClient = ({ hubspotForm, redirectURL }: Props) => {
 				console.log("Form submitted successfully:", name)
 				const emailAddress = data?.submissionValues?.email
 				if (emailAddress) {
-					posthog.identify(emailAddress)
+					identify(emailAddress)
 				}
 
-				posthog.capture("website-form-submission", {
+				capture("website-form-submission", {
 					name: name
 				})
 

--- a/components/agility-components/Pricing/GetPricePopup.tsx
+++ b/components/agility-components/Pricing/GetPricePopup.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx'
 import LoadingWidget from "components/common/LoadingWidget"
 import { Bouncy } from "components/micro/loaders/Bouncy"
 import { load } from 'cheerio'
-import { posthog } from 'posthog-js'
+import { capture, identify } from 'lib/analytics/posthog'
 
 interface Props {
 	hubSpotForm: HubspotForm
@@ -39,10 +39,10 @@ export default function GetPricePopup({ priceDialogOpen, setPriceDialogOpen, hub
 				console.log("Form submitted successfully:", hubSpotForm.name)
 				const emailAddress = data?.submissionValues?.email
 				if (emailAddress) {
-					posthog.identify(emailAddress);
+					identify(emailAddress);
 				}
 
-				posthog.capture('website-form-submission', {
+				capture('website-form-submission', {
 					name: hubSpotForm.name
 				});
 

--- a/components/agility-components/ResourceDetails/DownloadForm.client.tsx
+++ b/components/agility-components/ResourceDetails/DownloadForm.client.tsx
@@ -2,7 +2,7 @@
 "use client"
 import Script from "next/script"
 import { useCallback, useEffect, useRef } from "react"
-import posthog from "posthog-js"
+import { capture, identify } from "lib/analytics/posthog"
 import { useRouter } from 'next/navigation'
 
 interface IDownloadForm {
@@ -34,10 +34,10 @@ export const DownloadForm = ({ hubspotForm, redirectURL }: IDownloadForm) => {
 				console.log("Form submitted successfully:", name)
 				const emailAddress = data?.submissionValues?.email
 				if (emailAddress) {
-					posthog.identify(emailAddress);
+					identify(emailAddress);
 				}
 
-				posthog.capture('website-form-submission', {
+				capture('website-form-submission', {
 					name: name
 				});
 

--- a/components/agility-components/SubmissionForm/SubmissionForm.client.tsx
+++ b/components/agility-components/SubmissionForm/SubmissionForm.client.tsx
@@ -4,7 +4,7 @@ import Script from "next/script"
 import { ISubmissionForm } from "./SubmissionForm"
 import { useCallback, useEffect, useRef } from "react"
 import { Container } from "components/micro/Container"
-import { posthog } from "posthog-js"
+import { capture, identify } from "lib/analytics/posthog"
 import { useRouter } from "next/navigation"
 
 export const SubmissionFormClient = ({
@@ -35,10 +35,10 @@ export const SubmissionFormClient = ({
 				console.log("Form submitted successfully:", name)
 				const emailAddress = data?.submissionValues?.email
 				if (emailAddress) {
-					posthog.identify(emailAddress)
+					identify(emailAddress)
 				}
 
-				posthog.capture("website-form-submission", {
+				capture("website-form-submission", {
 					name: name
 				})
 

--- a/components/common/footer/FooterSubscribe.tsx
+++ b/components/common/footer/FooterSubscribe.tsx
@@ -4,7 +4,7 @@
 import { LinkButton } from "components/micro/LinkButton"
 import { HubspotForm } from "lib/types/HubspotForm"
 import Script from "next/script"
-import posthog from 'posthog-js'
+import { capture, identify } from 'lib/analytics/posthog'
 
 interface Props {
 	subscribeButtonLabel: string
@@ -46,10 +46,10 @@ export const FooterSubscribe = ({
 								console.log("Newsletter signup submitted.")
 								const emailAddress = data?.submissionValues?.email
 								if (emailAddress) {
-									posthog.identify(emailAddress);
+									identify(emailAddress);
 								}
 
-								posthog.capture('newsletter-signup');
+								capture('newsletter-signup');
 
 							}
 						})

--- a/components/search/Search.tsx
+++ b/components/search/Search.tsx
@@ -1,34 +1,12 @@
 'use client'
 
-import { liteClient } from 'algoliasearch/lite';
-
-import { getAlgoliaResults } from "@algolia/autocomplete-preset-algolia";
-
-
-
-
-import {
-	forwardRef,
-	Suspense,
-	useCallback,
-	useEffect,
-	useId,
-	useRef,
-	useState,
-} from 'react'
-
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import {
-	type AutocompleteApi,
-	type AutocompleteState,
-	createAutocomplete,
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
+import type {
+	AutocompleteApi,
+	AutocompleteState,
 } from '@algolia/autocomplete-core'
-import { Dialog, DialogPanel, DialogBackdrop } from '@headlessui/react'
-import clsx from 'clsx'
-import SearchResults from './SearchResults';
-import { SearchInput } from './SearchInput';
-import { SearchIcon } from './SearchIcon';
-
+import { SearchIcon } from './SearchIcon'
 
 export type Result = {
 	url: string
@@ -45,13 +23,6 @@ export type Result = {
 	__autocomplete_indexName?: string
 }
 
-const searchClient = liteClient(
-	process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || "",
-	process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY || ""
-);
-
-type EmptyObject = Record<string, never>
-
 export type Autocomplete = AutocompleteApi<
 	Result,
 	React.SyntheticEvent,
@@ -59,341 +30,40 @@ export type Autocomplete = AutocompleteApi<
 	React.KeyboardEvent
 >
 
-function useAutocomplete({ close }: { close: () => void }) {
-	let id = useId()
-	let router = useRouter()
-	let [autocompleteState, setAutocompleteState] = useState<
-		AutocompleteState<Result> | EmptyObject
-	>({})
+// Re-export AutocompleteState for SearchInput's type usage
+export type { AutocompleteState }
 
-	function navigate({ item }: { item: Result }) {
-
-		const itemUrl = item.url
-		if (!itemUrl) {
-			return
-		}
-
-		let url = itemUrl
-		if (url.startsWith("https://agilitycms.com")) {
-			//make absolutle URLs relative so they work locally and on deploy previews
-			url = url.replace("https://agilitycms.com", "")
-		} else if (url.startsWith('/')) {
-			//make the docs URLs absolute
-			url = `https://agilitycms.com/docs${url}`
-		}
-
-
-		router.push(url)
-
-		if (
-			itemUrl ===
-			window.location.pathname + window.location.search + window.location.hash
-		) {
-			close()
-		}
-	}
-
-
-	let [autocomplete] = useState<Autocomplete>(() =>
-		createAutocomplete<
-			Result,
-			React.SyntheticEvent,
-			React.MouseEvent,
-			React.KeyboardEvent
-		>({
-			id,
-			placeholder: 'Search...',
-			defaultActiveItemId: 0,
-			onStateChange({ state }) {
-				setAutocompleteState(state)
-			},
-			shouldPanelOpen({ state }) {
-				return state.query !== ''
-			},
-			navigator: {
-				navigate,
-			},
-			insights: true,
-			getSources({ query }) {
-				return [
-					{
-						sourceId: 'documentation',
-						getItems() {
-							return getAlgoliaResults({
-								searchClient,
-								queries: [
-									{
-										indexName: 'agility-website',
-										params: {
-											query,
-											hitsPerPage: 10,
-										},
-									},
-									{
-										indexName: 'doc_site',
-										params: {
-											query,
-											hitsPerPage: 10,
-										},
-									},
-								],
-							});
-						},
-						getItemUrl({ item }) {
-							return item.url
-						},
-						onSelect: navigate,
-					},
-				]
-			},
-		}),
-	)
-
-	return { autocomplete, autocompleteState }
-}
-
-
-
-
-
-
-
-
-
-
-
-function SearchDialog({
-	open,
-	setOpen,
-	className,
-}: {
-	open: boolean
-	setOpen: (open: boolean) => void
-	className?: string
-}) {
-	let formRef = useRef<React.ElementRef<'form'>>(null)
-	let panelRef = useRef<React.ElementRef<'div'>>(null)
-	let inputRef = useRef<React.ElementRef<typeof SearchInput>>(null)
-	let { autocomplete, autocompleteState } = useAutocomplete({
-		close() {
-			setOpen(false)
-		},
-	})
-	let pathname = usePathname()
-	let searchParams = useSearchParams()
-	let router = useRouter()
-
-	const [extraResults, setExtraResults] = useState<Result[]>([])
-	const [isLoadingMore, setIsLoadingMore] = useState(false)
-	const [totalHits, setTotalHits] = useState<number | null>(null)
-	const pageRef = useRef(0)
-	const queryRef = useRef('')
-	const isLoadingMoreRef = useRef(false)
-	const hasMoreRef = useRef(true)
-
-	useEffect(() => {
-		setOpen(false)
-	}, [pathname, searchParams, setOpen])
-
-	useEffect(() => {
-		if (open) {
-			return
-		}
-
-		function onKeyDown(event: KeyboardEvent) {
-			if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
-				event.preventDefault()
-				setOpen(true)
-			}
-		}
-
-		window.addEventListener('keydown', onKeyDown)
-
-		return () => {
-			window.removeEventListener('keydown', onKeyDown)
-		}
-	}, [open, setOpen])
-
-	// Reset pagination when query changes and fetch total count
-	useEffect(() => {
-		const query = (autocompleteState as AutocompleteState<Result>).query || ''
-		if (query !== queryRef.current) {
-			queryRef.current = query
-			pageRef.current = 0
-			isLoadingMoreRef.current = false
-			hasMoreRef.current = true
-			setExtraResults([])
-			setIsLoadingMore(false)
-			setTotalHits(null)
-
-			// Scroll results panel back to top so a new query doesn't auto-load more
-			if (panelRef.current) {
-				panelRef.current.scrollTop = 0
-			}
-
-			if (query) {
-				searchClient.search({
-					requests: [
-						{ indexName: 'agility-website', query, hitsPerPage: 0 },
-						{ indexName: 'doc_site', query, hitsPerPage: 0 },
-					]
-				}).then((response: any) => {
-					if (queryRef.current === query) {
-						const total = response.results.reduce(
-							(sum: number, r: any) => sum + (r.nbHits || 0), 0
-						)
-						setTotalHits(total)
-					}
-				}).catch(() => {})
-			}
-		}
-	}, [autocompleteState])
-
-	function navigateToResult(result: Result) {
-		let url = result.url
-		if (!url) return
-		if (url.startsWith("https://agilitycms.com")) {
-			url = url.replace("https://agilitycms.com", "")
-		} else if (url.startsWith('/')) {
-			url = `https://agilitycms.com/docs${url}`
-		}
-		router.push(url)
-		setOpen(false)
-	}
-
-	const loadMore = useCallback(async () => {
-		const query = queryRef.current
-		if (!query || isLoadingMoreRef.current || !hasMoreRef.current) return
-
-		isLoadingMoreRef.current = true
-		setIsLoadingMore(true)
-		const nextPage = pageRef.current + 1
-
-		try {
-			const response: any = await searchClient.search({
-				requests: [
-					{ indexName: 'agility-website', query, hitsPerPage: 10, page: nextPage },
-					{ indexName: 'doc_site', query, hitsPerPage: 10, page: nextPage },
-				]
-			})
-
-			if (queryRef.current !== query) return
-
-			const newResults: Result[] = []
-			for (let i = 0; i < response.results.length; i++) {
-				const indexName = i === 0 ? 'agility-website' : 'doc_site'
-				for (const hit of (response.results[i].hits || [])) {
-					newResults.push({
-						url: hit.url,
-						title: hit.title,
-						description: hit.description,
-						ogImage: hit.ogImage,
-						section: hit.section,
-						concept: hit.concept,
-						publishedDate: hit.publishedDate,
-						contentType: hit.contentType,
-						__autocomplete_indexName: indexName,
-					})
-				}
-			}
-
-			if (newResults.length === 0) {
-				hasMoreRef.current = false
-			} else {
-				const idxA = newResults.filter(r => r.__autocomplete_indexName !== 'doc_site')
-				const idxB = newResults.filter(r => r.__autocomplete_indexName === 'doc_site')
-				const interleaved: Result[] = []
-				const maxLen = Math.max(idxA.length, idxB.length)
-				for (let i = 0; i < maxLen; i++) {
-					if (i < idxA.length) interleaved.push(idxA[i])
-					if (i < idxB.length) interleaved.push(idxB[i])
-				}
-				setExtraResults(prev => [...prev, ...interleaved])
-				pageRef.current = nextPage
-			}
-		} catch {
-			// ignore errors
-		} finally {
-			if (queryRef.current === query) {
-				isLoadingMoreRef.current = false
-				setIsLoadingMore(false)
-			}
-		}
-	}, [])
-
-	const handlePanelScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-		const { scrollTop, scrollHeight, clientHeight } = e.currentTarget
-		if (scrollHeight - scrollTop - clientHeight < 150) {
-			loadMore()
-		}
-	}, [loadMore])
-
-	return (
-		<Dialog
-			open={open}
-			onClose={() => {
-				setOpen(false)
-				autocomplete.setQuery('')
-			}}
-			className={clsx('fixed inset-0 z-50', className)}
-		>
-			<DialogBackdrop
-				transition
-				className="fixed inset-0 bg-zinc-400/25 backdrop-blur-sm data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in "
-			/>
-
-			<div className="fixed inset-0 overflow-y-auto px-4 py-4 sm:px-6 sm:py-20 md:py-32 lg:px-8 lg:py-[15vh]">
-				<DialogPanel
-					transition
-					className="mx-auto transform-gpu overflow-hidden rounded-lg bg-zinc-50 shadow-xl ring-1 ring-zinc-900/7.5 data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in sm:max-w-xl  "
-				>
-					<div {...autocomplete.getRootProps({})}>
-						<form
-							ref={formRef}
-							{...autocomplete.getFormProps({
-								inputElement: inputRef.current,
-							})}
-						>
-							<SearchInput
-								ref={inputRef}
-								autocomplete={autocomplete}
-								autocompleteState={autocompleteState}
-								onClose={() => setOpen(false)}
-							/>
-							<div
-								ref={panelRef}
-								className="border-t border-zinc-200 bg-white empty:hidden max-h-[70vh] overflow-y-auto"
-								{...autocomplete.getPanelProps({})}
-								onScroll={handlePanelScroll}
-							>
-								{autocompleteState.isOpen && (
-									<SearchResults
-										autocomplete={autocomplete}
-										query={autocompleteState.query}
-										collection={autocompleteState.collections[0]}
-										extraResults={extraResults}
-										isLoadingMore={isLoadingMore}
-										totalHits={totalHits}
-										onExtraResultClick={navigateToResult}
-									/>
-								)}
-							</div>
-						</form>
-					</div>
-				</DialogPanel>
-			</div>
-		</Dialog>
-	)
-}
+const SearchDialog = dynamic(
+	() => import('./SearchDialog').then((m) => m.SearchDialog),
+	{ ssr: false }
+)
 
 function useSearchProps() {
 	let buttonRef = useRef<React.ElementRef<'button'>>(null)
 	let [open, setOpen] = useState(false)
+	let [mounted, setMounted] = useState(false)
+
+	// cmd/ctrl+K opens the dialog. Lifted out of SearchDialog so the
+	// shortcut works without paying for the dialog JS upfront.
+	useEffect(() => {
+		function onKeyDown(event: KeyboardEvent) {
+			if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
+				event.preventDefault()
+				setMounted(true)
+				setOpen(true)
+			}
+		}
+		window.addEventListener('keydown', onKeyDown)
+		return () => {
+			window.removeEventListener('keydown', onKeyDown)
+		}
+	}, [])
 
 	return {
 		buttonProps: {
 			ref: buttonRef,
 			onClick() {
+				setMounted(true)
 				setOpen(true)
 			},
 		},
@@ -410,12 +80,13 @@ function useSearchProps() {
 				[setOpen],
 			),
 		},
+		mounted,
 	}
 }
 
 export function Search() {
 	let [modifierKey, setModifierKey] = useState<string>()
-	let { buttonProps, dialogProps } = useSearchProps()
+	let { buttonProps, dialogProps, mounted } = useSearchProps()
 
 	useEffect(() => {
 		setModifierKey(
@@ -438,15 +109,17 @@ export function Search() {
 				<SearchIcon className="h-5 w-5 flex-shrink-0 stroke-white stroke-2 group-hover:stroke-secondary transition-colors" />
 
 			</button>
-			<Suspense fallback={null}>
-				<SearchDialog className="hidden lg:block" {...dialogProps} />
-			</Suspense>
+			{mounted && (
+				<Suspense fallback={null}>
+					<SearchDialog className="hidden lg:block" {...dialogProps} />
+				</Suspense>
+			)}
 		</div>
 	)
 }
 
 export function MobileSearch() {
-	let { buttonProps, dialogProps } = useSearchProps()
+	let { buttonProps, dialogProps, mounted } = useSearchProps()
 
 	return (
 		<div className="contents lg:hidden">
@@ -458,9 +131,11 @@ export function MobileSearch() {
 			>
 				<SearchIcon className="h-5 w-5 stroke-zinc-900 " />
 			</button>
-			<Suspense fallback={null}>
-				<SearchDialog className="lg:hidden" {...dialogProps} />
-			</Suspense>
+			{mounted && (
+				<Suspense fallback={null}>
+					<SearchDialog className="lg:hidden" {...dialogProps} />
+				</Suspense>
+			)}
 		</div>
 	)
 }

--- a/components/search/SearchDialog.tsx
+++ b/components/search/SearchDialog.tsx
@@ -1,0 +1,319 @@
+'use client'
+
+import { liteClient } from 'algoliasearch/lite'
+import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia'
+import {
+	useCallback,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+} from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+	type AutocompleteState,
+	createAutocomplete,
+} from '@algolia/autocomplete-core'
+import { Dialog, DialogPanel, DialogBackdrop } from '@headlessui/react'
+import clsx from 'clsx'
+import SearchResults from './SearchResults'
+import { SearchInput } from './SearchInput'
+import type { Autocomplete, Result } from './Search'
+
+type EmptyObject = Record<string, never>
+
+const searchClient = liteClient(
+	process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '',
+	process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY || ''
+)
+
+function useAutocomplete({ close }: { close: () => void }) {
+	let id = useId()
+	let router = useRouter()
+	let [autocompleteState, setAutocompleteState] = useState<
+		AutocompleteState<Result> | EmptyObject
+	>({})
+
+	function navigate({ item }: { item: Result }) {
+		const itemUrl = item.url
+		if (!itemUrl) {
+			return
+		}
+
+		let url = itemUrl
+		if (url.startsWith('https://agilitycms.com')) {
+			url = url.replace('https://agilitycms.com', '')
+		} else if (url.startsWith('/')) {
+			url = `https://agilitycms.com/docs${url}`
+		}
+
+		router.push(url)
+
+		if (
+			itemUrl ===
+			window.location.pathname + window.location.search + window.location.hash
+		) {
+			close()
+		}
+	}
+
+	let [autocomplete] = useState<Autocomplete>(() =>
+		createAutocomplete<
+			Result,
+			React.SyntheticEvent,
+			React.MouseEvent,
+			React.KeyboardEvent
+		>({
+			id,
+			placeholder: 'Search...',
+			defaultActiveItemId: 0,
+			onStateChange({ state }) {
+				setAutocompleteState(state)
+			},
+			shouldPanelOpen({ state }) {
+				return state.query !== ''
+			},
+			navigator: {
+				navigate,
+			},
+			insights: true,
+			getSources({ query }) {
+				return [
+					{
+						sourceId: 'documentation',
+						getItems() {
+							return getAlgoliaResults({
+								searchClient,
+								queries: [
+									{
+										indexName: 'agility-website',
+										params: {
+											query,
+											hitsPerPage: 10,
+										},
+									},
+									{
+										indexName: 'doc_site',
+										params: {
+											query,
+											hitsPerPage: 10,
+										},
+									},
+								],
+							})
+						},
+						getItemUrl({ item }) {
+							return item.url
+						},
+						onSelect: navigate,
+					},
+				]
+			},
+		})
+	)
+
+	return { autocomplete, autocompleteState }
+}
+
+export function SearchDialog({
+	open,
+	setOpen,
+	className,
+}: {
+	open: boolean
+	setOpen: (open: boolean) => void
+	className?: string
+}) {
+	let formRef = useRef<React.ElementRef<'form'>>(null)
+	let panelRef = useRef<React.ElementRef<'div'>>(null)
+	let inputRef = useRef<React.ElementRef<typeof SearchInput>>(null)
+	let { autocomplete, autocompleteState } = useAutocomplete({
+		close() {
+			setOpen(false)
+		},
+	})
+	let pathname = usePathname()
+	let searchParams = useSearchParams()
+	let router = useRouter()
+
+	const [extraResults, setExtraResults] = useState<Result[]>([])
+	const [isLoadingMore, setIsLoadingMore] = useState(false)
+	const [totalHits, setTotalHits] = useState<number | null>(null)
+	const pageRef = useRef(0)
+	const queryRef = useRef('')
+	const isLoadingMoreRef = useRef(false)
+	const hasMoreRef = useRef(true)
+
+	useEffect(() => {
+		setOpen(false)
+	}, [pathname, searchParams, setOpen])
+
+	useEffect(() => {
+		const query = (autocompleteState as AutocompleteState<Result>).query || ''
+		if (query !== queryRef.current) {
+			queryRef.current = query
+			pageRef.current = 0
+			isLoadingMoreRef.current = false
+			hasMoreRef.current = true
+			setExtraResults([])
+			setIsLoadingMore(false)
+			setTotalHits(null)
+
+			if (panelRef.current) {
+				panelRef.current.scrollTop = 0
+			}
+
+			if (query) {
+				searchClient.search({
+					requests: [
+						{ indexName: 'agility-website', query, hitsPerPage: 0 },
+						{ indexName: 'doc_site', query, hitsPerPage: 0 },
+					]
+				}).then((response: any) => {
+					if (queryRef.current === query) {
+						const total = response.results.reduce(
+							(sum: number, r: any) => sum + (r.nbHits || 0), 0
+						)
+						setTotalHits(total)
+					}
+				}).catch(() => { })
+			}
+		}
+	}, [autocompleteState])
+
+	function navigateToResult(result: Result) {
+		let url = result.url
+		if (!url) return
+		if (url.startsWith('https://agilitycms.com')) {
+			url = url.replace('https://agilitycms.com', '')
+		} else if (url.startsWith('/')) {
+			url = `https://agilitycms.com/docs${url}`
+		}
+		router.push(url)
+		setOpen(false)
+	}
+
+	const loadMore = useCallback(async () => {
+		const query = queryRef.current
+		if (!query || isLoadingMoreRef.current || !hasMoreRef.current) return
+
+		isLoadingMoreRef.current = true
+		setIsLoadingMore(true)
+		const nextPage = pageRef.current + 1
+
+		try {
+			const response: any = await searchClient.search({
+				requests: [
+					{ indexName: 'agility-website', query, hitsPerPage: 10, page: nextPage },
+					{ indexName: 'doc_site', query, hitsPerPage: 10, page: nextPage },
+				]
+			})
+
+			if (queryRef.current !== query) return
+
+			const newResults: Result[] = []
+			for (let i = 0; i < response.results.length; i++) {
+				const indexName = i === 0 ? 'agility-website' : 'doc_site'
+				for (const hit of (response.results[i].hits || [])) {
+					newResults.push({
+						url: hit.url,
+						title: hit.title,
+						description: hit.description,
+						ogImage: hit.ogImage,
+						section: hit.section,
+						concept: hit.concept,
+						publishedDate: hit.publishedDate,
+						contentType: hit.contentType,
+						__autocomplete_indexName: indexName,
+					})
+				}
+			}
+
+			if (newResults.length === 0) {
+				hasMoreRef.current = false
+			} else {
+				const idxA = newResults.filter(r => r.__autocomplete_indexName !== 'doc_site')
+				const idxB = newResults.filter(r => r.__autocomplete_indexName === 'doc_site')
+				const interleaved: Result[] = []
+				const maxLen = Math.max(idxA.length, idxB.length)
+				for (let i = 0; i < maxLen; i++) {
+					if (i < idxA.length) interleaved.push(idxA[i])
+					if (i < idxB.length) interleaved.push(idxB[i])
+				}
+				setExtraResults(prev => [...prev, ...interleaved])
+				pageRef.current = nextPage
+			}
+		} catch {
+			// ignore errors
+		} finally {
+			if (queryRef.current === query) {
+				isLoadingMoreRef.current = false
+				setIsLoadingMore(false)
+			}
+		}
+	}, [])
+
+	const handlePanelScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+		const { scrollTop, scrollHeight, clientHeight } = e.currentTarget
+		if (scrollHeight - scrollTop - clientHeight < 150) {
+			loadMore()
+		}
+	}, [loadMore])
+
+	return (
+		<Dialog
+			open={open}
+			onClose={() => {
+				setOpen(false)
+				autocomplete.setQuery('')
+			}}
+			className={clsx('fixed inset-0 z-50', className)}
+		>
+			<DialogBackdrop
+				transition
+				className="fixed inset-0 bg-zinc-400/25 backdrop-blur-sm data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in "
+			/>
+
+			<div className="fixed inset-0 overflow-y-auto px-4 py-4 sm:px-6 sm:py-20 md:py-32 lg:px-8 lg:py-[15vh]">
+				<DialogPanel
+					transition
+					className="mx-auto transform-gpu overflow-hidden rounded-lg bg-zinc-50 shadow-xl ring-1 ring-zinc-900/7.5 data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in sm:max-w-xl  "
+				>
+					<div {...autocomplete.getRootProps({})}>
+						<form
+							ref={formRef}
+							{...autocomplete.getFormProps({
+								inputElement: inputRef.current,
+							})}
+						>
+							<SearchInput
+								ref={inputRef}
+								autocomplete={autocomplete}
+								autocompleteState={autocompleteState}
+								onClose={() => setOpen(false)}
+							/>
+							<div
+								ref={panelRef}
+								className="border-t border-zinc-200 bg-white empty:hidden max-h-[70vh] overflow-y-auto"
+								{...autocomplete.getPanelProps({})}
+								onScroll={handlePanelScroll}
+							>
+								{autocompleteState.isOpen && (
+									<SearchResults
+										autocomplete={autocomplete}
+										query={autocompleteState.query}
+										collection={autocompleteState.collections[0]}
+										extraResults={extraResults}
+										isLoadingMore={isLoadingMore}
+										totalHits={totalHits}
+										onExtraResultClick={navigateToResult}
+									/>
+								)}
+							</div>
+						</form>
+					</div>
+				</DialogPanel>
+			</div>
+		</Dialog>
+	)
+}

--- a/lib/analytics/posthog.ts
+++ b/lib/analytics/posthog.ts
@@ -1,0 +1,82 @@
+// Lazy-loaded PostHog wrapper. Do not import posthog-js directly elsewhere —
+// use `capture` / `identify` from this module so posthog-js stays out of the
+// initial JS bundle.
+
+type PostHogModule = typeof import('posthog-js')['default']
+
+let instance: PostHogModule | null = null
+let loadPromise: Promise<PostHogModule | null> | null = null
+const queue: Array<(ph: PostHogModule) => void> = []
+
+function shouldLoad(): boolean {
+	return typeof window !== 'undefined' && !!process.env.NEXT_PUBLIC_POSTHOG_KEY
+}
+
+function load(): Promise<PostHogModule | null> {
+	if (!shouldLoad()) return Promise.resolve(null)
+	if (loadPromise) return loadPromise
+
+	loadPromise = import('posthog-js').then((m) => {
+		const posthog = m.default
+		posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+			api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+			defaults: '2025-05-24',
+			before_send: (event) => {
+				const exceptionList = event?.properties?.['$exception_list']
+				if (
+					Array.isArray(exceptionList) &&
+					exceptionList.some((e: any) =>
+						e?.value?.includes('ResizeObserver loop')
+					)
+				) {
+					return null
+				}
+				return event
+			},
+		})
+		instance = posthog
+		while (queue.length) {
+			const fn = queue.shift()!
+			fn(posthog)
+		}
+		return posthog
+	})
+	return loadPromise
+}
+
+// Schedule the load during browser idle time. Falls back to setTimeout for
+// Safari < 16.4 which lacks requestIdleCallback.
+export function initPostHog() {
+	if (!shouldLoad()) return
+	const w = window as typeof window & {
+		requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number
+	}
+	if (typeof w.requestIdleCallback === 'function') {
+		w.requestIdleCallback(() => { load() }, { timeout: 2000 })
+	} else {
+		setTimeout(() => { load() }, 1000)
+	}
+}
+
+export function capture(event: string, properties?: Record<string, unknown>) {
+	if (instance) {
+		instance.capture(event, properties)
+	} else {
+		queue.push((ph) => ph.capture(event, properties))
+		// If a capture is called before initPostHog() has run, trigger the load
+		// so the event eventually fires.
+		load()
+	}
+}
+
+export function identify(
+	distinctId: string,
+	properties?: Record<string, unknown>
+) {
+	if (instance) {
+		instance.identify(distinctId, properties)
+	} else {
+		queue.push((ph) => ph.identify(distinctId, properties))
+		load()
+	}
+}


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1552
Closes https://agilitycms.atlassian.net/browse/PROD-1526

## Summary
- Gate `web-studio-sdk` so it only loads in preview/dev mode (production visitors no longer download the CMS-editor SDK).
- Lazy-load `posthog-js` via a small wrapper (`lib/analytics/posthog.ts`) — removes ~50 KB gzipped from every page's First Load JS while preserving all tracking.
- Code-split the search dialog: `react-highlight-words`, `algoliasearch`, `@algolia/autocomplete-core`, and `@headlessui/react` Dialog now load only when a user opens search.

## Test plan
- [ ] Open the preview, search button (and cmd+K) still opens the dialog and returns Algolia results.
- [ ] Submit any form (footer subscribe, gated download, get a demo, etc.) — confirm PostHog dashboard sees the event with the right email and properties.
