### PR TITLE
perf: cache getHeaderContent with unstable_cache

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -61,6 +61,13 @@ export async function POST(req: NextRequest, res: NextResponse) {
 			revalidateTag(itemTag)
 			revalidateTag(listTag)
 
+			// Bust the cached getHeaderContent result when the globalheader item publishes.
+			// Sub-nav / mega-menu changes still propagate within the unstable_cache TTL.
+			if (data.referenceName === "globalheader") {
+				revalidateTag("header-content")
+				console.info("Revalidating header-content tag")
+			}
+
 			console.info("Revalidating content tags:", itemTag, listTag)
 
 			//grab the sitemap and check if this content is in there so we can revalidate a full path

--- a/lib/cms-content/getHeaderContent.ts
+++ b/lib/cms-content/getHeaderContent.ts
@@ -5,9 +5,7 @@ import { Header } from "lib/types/Header"
 import { TopLevelNav } from "lib/types/TopLevelNav"
 import { SubLevelNav } from "lib/types/SubLevelNav"
 import { MegaMenuItem } from "lib/types/MegaMenuItem"
-
-
-
+import { unstable_cache } from "next/cache"
 
 interface Props {
 	locale: string
@@ -15,7 +13,7 @@ interface Props {
 }
 
 export interface MenuLink {
-	menuItem: ContentItem<TopLevelNav>,
+	menuItem: ContentItem<TopLevelNav>
 	subMenuList?: ContentItem<SubLevelNav>[]
 	megaMenuList?: ContentItem<MegaMenuItem>[]
 }
@@ -41,9 +39,7 @@ export interface HeaderContent {
  * @param {Props} { locale, sitemap }
  * @return {*}
  */
-export const getHeaderContent = async ({ locale, sitemap }: Props): Promise<HeaderContent> => {
-
-
+const fetchHeaderContent = async ({ locale, sitemap }: Props): Promise<HeaderContent> => {
 	// set up content item
 	let header: ContentItem<Header> | null = null
 
@@ -70,17 +66,27 @@ export const getHeaderContent = async ({ locale, sitemap }: Props): Promise<Head
 		//expand out the menu structure with MULTIPLE CALLS so that we can purge the cache for any level :)
 		const [menuStructureList, preHeaderLinksList] = await Promise.all([
 			header.fields.menuStructure?.referencename
-				? getContentList({ referenceName: header.fields.menuStructure.referencename, languageCode: locale, contentLinkDepth: 0 })
+				? getContentList({
+						referenceName: header.fields.menuStructure.referencename,
+						languageCode: locale,
+						contentLinkDepth: 0
+					})
 				: Promise.resolve(null),
 			header.fields.preHeaderLinks?.referencename
-				? getContentList({ referenceName: header.fields.preHeaderLinks.referencename, languageCode: locale, take: 5, contentLinkDepth: 0 })
-				: Promise.resolve(null),
+				? getContentList({
+						referenceName: header.fields.preHeaderLinks.referencename,
+						languageCode: locale,
+						take: 5,
+						contentLinkDepth: 0
+					})
+				: Promise.resolve(null)
 		])
 
-		const preheaderLinks: BasicLink[] = preHeaderLinksList?.items.map((item: any) => ({
-			title: item.fields.title,
-			url: item.fields.uRL
-		})) || []
+		const preheaderLinks: BasicLink[] =
+			preHeaderLinksList?.items.map((item: any) => ({
+				title: item.fields.title,
+				url: item.fields.uRL
+			})) || []
 
 		// Phase 3: fetch all mega menus and sub-navs in parallel across all menu items
 		if (menuStructureList) {
@@ -88,17 +94,29 @@ export const getHeaderContent = async ({ locale, sitemap }: Props): Promise<Head
 				menuStructureList.items.map(async (menuItem: ContentItem<TopLevelNav>) => {
 					const [megaMenuRes, subNavRes] = await Promise.all([
 						menuItem.fields.megaContent?.referencename
-							? getContentList({ referenceName: menuItem.fields.megaContent.referencename, languageCode: locale })
+							? getContentList({
+									referenceName: menuItem.fields.megaContent.referencename,
+									languageCode: locale
+								})
 							: Promise.resolve(null),
 						menuItem.fields.subNavigation?.referencename
-							? getContentList({ referenceName: menuItem.fields.subNavigation.referencename, languageCode: locale, contentLinkDepth: 0, take: 100 })
-							: Promise.resolve(null),
+							? getContentList({
+									referenceName: menuItem.fields.subNavigation.referencename,
+									languageCode: locale,
+									contentLinkDepth: 0,
+									take: 100
+								})
+							: Promise.resolve(null)
 					])
 
 					return {
 						menuItem,
-						megaMenuList: megaMenuRes?.items?.length ? megaMenuRes.items as ContentItem<MegaMenuItem>[] : undefined,
-						subMenuList: subNavRes?.items?.length ? subNavRes.items as ContentItem<SubLevelNav>[] : undefined,
+						megaMenuList: megaMenuRes?.items?.length
+							? (megaMenuRes.items as ContentItem<MegaMenuItem>[])
+							: undefined,
+						subMenuList: subNavRes?.items?.length
+							? (subNavRes.items as ContentItem<SubLevelNav>[])
+							: undefined
 					}
 				})
 			)
@@ -109,15 +127,17 @@ export const getHeaderContent = async ({ locale, sitemap }: Props): Promise<Head
 			links,
 			preheaderLinks
 		}
-
 	} catch (error) {
 		if (console) console.error("Could not load site header item.", error)
 		throw new Error("Could not load site header.")
 	}
-
-
-
 }
 
-
-
+// Cache the fully-transformed header so the layout doesn't re-run 6+ CMS
+// fetches + their response mapping on every request. 5-minute backstop;
+// the `header-content` tag is revalidated by /api/revalidate when the
+// globalheader content publishes (see app/api/revalidate/route.ts).
+export const getHeaderContent = unstable_cache(fetchHeaderContent, ["getHeaderContent"], {
+	revalidate: 300,
+	tags: ["header-content"]
+})


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1537

## Summary
- Wraps `getHeaderContent` in `unstable_cache` (5-min TTL, `header-content` tag) so the layout's 6+ CMS calls + response transformation only happen once per cache window instead of on every request.
- Webhook revalidates the tag when `globalheader` publishes for instant editor refresh; sub-nav / mega-menu edits propagate within the TTL.

## Build proof
Verified with a temporary `console.log` inside the un-cached inner function: across the 1,422-page static build, the function ran ~10 times (one per parallel worker) instead of 1,422 times. ~99% reduction in header-related CMS calls.

## Test plan
- [ ] `yarn build` completes cleanly with no new warnings.
- [ ] Publish the `globalheader` content in CMS; confirm webhook logs `Revalidating header-content tag` and the change appears on the live site immediately (not after 5 min).
- [ ] Edit a sub-nav / mega-menu item without re-publishing `globalheader`; confirm the change appears within ~5 min.
