### PR TITLE
perf: AVIF/WebP image formats + 1-year cache TTL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,13 @@ const nextConfig = {
 				hostname: '*.aglty.io',
 			},
 		],
+		// Prefer AVIF (smaller than WebP), fall back to WebP for older browsers.
+		// Browsers that support neither get the original format.
+		formats: ['image/avif', 'image/webp'],
+		// Cache optimized images for a year (Next.js default is 60 seconds, which
+		// means images get re-optimized constantly). Sets the Cache-Control header
+		// on /_next/image responses and controls server-side image cache lifetime.
+		minimumCacheTTL: 31536000,
 	},
 	redirects() {
 		return [


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1535

## Summary
Adds two settings to `next.config.js → images`:
- **`formats: ['image/avif', 'image/webp']`** — browsers that support AVIF (Chrome 85+, Firefox 93+, Safari 16+) receive AVIF, which is typically 30–50% smaller than WebP. Older browsers get WebP, then the original. No client code changes needed.
- **`minimumCacheTTL: 31536000`** (1 year) — Next.js default is 60s, which means optimized images get re-encoded on every request after the minute is up and clients re-fetch them. Long TTL means the optimization happens once per `(image, size)` pair and the `Cache-Control` on `/_next/image` responses tells browsers to cache for a year.

## Bundle impact
**Zero** — this is a runtime image optimization change. JS route table is unchanged.

## Where the wins show up
Browser network tab: smaller image bytes (AVIF) and fewer image requests on repeat visits (cached). Directly helps LCP on image-heavy pages.

## Test plan
- [x] Build completes cleanly.
- [ ] Reviewer: load any image-heavy page in a modern browser. Open DevTools → Network → filter `/_next/image`. Confirm:
  - Response `Content-Type` is `image/avif` (Chrome/Firefox) or `image/webp` (older Safari).
  - Response includes `Cache-Control: public, max-age=31536000, must-revalidate` (or similar long TTL).
