### PR TITLE
perf: add width/height to raw <img> tags to prevent CLS

### DIFF
--- a/components/agility-components/RightOrLeftSteps.tsx
+++ b/components/agility-components/RightOrLeftSteps.tsx
@@ -49,7 +49,13 @@ const RightOrLeftSteps = async ({ module, languageCode }: UnloadedModuleProps) =
 						{image.url.endsWith(".svg") ? (
 							//don't need to use AgilityPic for SVGs
 							// eslint-disable-next-line @next/next/no-img-element
-							<img src={image.url} alt={image.label} className="w-full" />
+							<img
+								src={image.url}
+								alt={image.label}
+								className="w-full"
+								width={image.width || 600}
+								height={image.height || 400}
+							/>
 						) : (
 							<AgilityPic
 								image={image}

--- a/components/agility-components/TriplePanelModule.tsx
+++ b/components/agility-components/TriplePanelModule.tsx
@@ -67,6 +67,8 @@ export const TriplePanelModule = async ({ module, languageCode }: UnloadedModule
 											src={item.fields.graphic.url}
 											alt={item.fields.graphic.label}
 											className="w-16"
+											width={item.fields.graphic.width || 64}
+											height={item.fields.graphic.height || 64}
 										/>
 									) : (
 										<AgilityPic image={item.fields.graphic} className="w-16" fallbackWidth={63} />


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1520
Closes https://agilitycms.atlassian.net/browse/PROD-1521
Closes https://agilitycms.atlassian.net/browse/PROD-1523

## Summary
Adds `width` and `height` attributes to two SVG-fallback `<img>` tags that were rendering without them. Without these attributes, the browser can't reserve space for the image before it loads, causing layout shift as surrounding content reflows.

- `RightOrLeftSteps.tsx` — full-width content image (Audit #8)
- `TriplePanelModule.tsx` — small panel graphic (Audit #10)

Tailwind classes (`w-full`, `w-16`) still control the displayed width. The `width`/`height` attributes only provide the intrinsic aspect ratio used for layout reservation.

## Audit #7 not addressed
`FeatureBlocks.tsx` was flagged in the original audit but already had `width="112" height="112"`. The audit's "missing height attribute" claim was wrong. No change needed there.

## Test plan
- [x] Build completes cleanly.
- [ ] Reviewer: load a page using `RightOrLeftSteps` and a page using `TriplePanelModule` with images. Use DevTools → Performance Insights → Layout Shifts to verify no CLS comes from these images.
