### PR TITLE
perf: dynamic-import all carousel client components

### DIFF
--- a/components/agility-components/CaseStudyDetails/CaseStudyDetails.tsx
+++ b/components/agility-components/CaseStudyDetails/CaseStudyDetails.tsx
@@ -3,13 +3,21 @@ import { Container } from "components/micro/Container"
 import { ICaseStudy } from "lib/types/ICaseStudy"
 import Link from "next/link"
 import { IconQuote } from "@tabler/icons-react"
-import { CaseStudyDetailRotator } from "./CaseStudyDetailRotator"
 import { ResourceCard } from "./ResourceCard"
 import { stripHtml } from "lib/utils/strip-html"
-import { CaseStudyRotatorClient, MinCaseStudy } from "../CaseStudyRotator/CaseStudyRotator.client"
+import type { MinCaseStudy } from "../CaseStudyRotator/CaseStudyRotator.client"
 import { getContentItem } from "lib/cms/getContentItem"
 import { SharePage } from "components/common/SharePage"
 import { renderHTMLCustom } from "lib/utils/renderHtmlCustom"
+import dynamic from "next/dynamic"
+
+const CaseStudyRotatorClient = dynamic(() =>
+	import("../CaseStudyRotator/CaseStudyRotator.client").then((m) => m.CaseStudyRotatorClient)
+)
+
+const CaseStudyDetailRotator = dynamic(() =>
+	import("./CaseStudyDetailRotator").then((m) => m.CaseStudyDetailRotator)
+)
 
 interface ICaseStudyDetails {
 	relatedCaseStudiesHeading: string

--- a/components/agility-components/CaseStudyRotator/CaseStudyRotator.tsx
+++ b/components/agility-components/CaseStudyRotator/CaseStudyRotator.tsx
@@ -4,8 +4,14 @@ import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
 import { getContentList } from "lib/cms/getContentList"
 import { ICaseStudy } from "lib/types/ICaseStudy"
-import { CaseStudyRotatorClient, MinCaseStudy } from "./CaseStudyRotator.client"
+import type { MinCaseStudy } from "./CaseStudyRotator.client"
 import { stripHtml } from "lib/utils/strip-html"
+import dynamic from "next/dynamic"
+
+// Defer the embla-carousel-powered rotator until after initial render.
+const CaseStudyRotatorClient = dynamic(() =>
+	import("./CaseStudyRotator.client").then((m) => m.CaseStudyRotatorClient)
+)
 
 interface ICaseStudyRotator {
 	title: string

--- a/components/agility-components/EventListing/EventListing.server.tsx
+++ b/components/agility-components/EventListing/EventListing.server.tsx
@@ -1,13 +1,18 @@
 import React from "react"
 
 import { useAgilityContext } from "lib/cms/useAgilityContext"
-import { EventListingClient } from "./EventListing.client"
 import { getContentItem } from "lib/cms/getContentItem"
 import { UnloadedModuleProps } from "@agility/nextjs"
 import { getEventListing } from "lib/cms-content/getEventListing"
 import { Container } from "components/micro/Container"
 import { ThreeDashLine } from "components/micro/ThreeDashLine"
 import { renderHTMLCustom } from "lib/utils/renderHtmlCustom"
+import dynamic from "next/dynamic"
+
+// Defer the infinite-scroll listing client until after initial render.
+const EventListingClient = dynamic(() =>
+	import("./EventListing.client").then((m) => m.EventListingClient)
+)
 
 interface IEventListing {
 	title?: string

--- a/components/agility-components/LogoListing/LogoListing.server.tsx
+++ b/components/agility-components/LogoListing/LogoListing.server.tsx
@@ -1,10 +1,14 @@
 import { UnloadedModuleProps, ImageField, ContentItem } from "@agility/nextjs"
 import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
-import { LogoListingClient } from "./LogoListing.client"
 import { sampleSize, shuffle } from "lodash"
 import { getContentList } from "lib/cms/getContentList"
 import { ThreeDashLine } from "components/micro/ThreeDashLine"
+import dynamic from "next/dynamic"
+
+const LogoListingClient = dynamic(() =>
+	import("./LogoListing.client").then((m) => m.LogoListingClient)
+)
 
 export interface LogoItem {
 	title: string

--- a/components/agility-components/LogoListingModule/LogoListingModule.server.tsx
+++ b/components/agility-components/LogoListingModule/LogoListingModule.server.tsx
@@ -1,8 +1,12 @@
 import { UnloadedModuleProps, ImageField, URLField, ContentItem } from "@agility/nextjs"
 import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
-import { LogoListingModuleClient } from "./LogoListingModule.client"
 import { shuffle } from "lodash"
+import dynamic from "next/dynamic"
+
+const LogoListingModuleClient = dynamic(() =>
+	import("./LogoListingModule.client").then((m) => m.LogoListingModuleClient)
+)
 
 export interface LogoItem {
 	title: string

--- a/components/agility-components/PartnerDetails/PartnerDetails.tsx
+++ b/components/agility-components/PartnerDetails/PartnerDetails.tsx
@@ -9,9 +9,13 @@ import { IPartner } from "lib/types/IPartner"
 import Link from "next/link"
 import { PartnerListingItem } from "../PartnerListing/PartnerListingItem"
 import { getContentList } from "lib/cms/getContentList"
-import { CaseStudyDetailRotator } from "../CaseStudyDetails/CaseStudyDetailRotator"
 import { GuideLink, GuideWithLinks } from "components/common/GuideWithLinks"
 import { renderHTMLCustom } from "lib/utils/renderHtmlCustom"
+import dynamic from "next/dynamic"
+
+const CaseStudyDetailRotator = dynamic(() =>
+	import("../CaseStudyDetails/CaseStudyDetailRotator").then((m) => m.CaseStudyDetailRotator)
+)
 
 interface IPartnerDetails {
 	cTAContent: string

--- a/components/agility-components/PartnerListing/PartnerListing.tsx
+++ b/components/agility-components/PartnerListing/PartnerListing.tsx
@@ -2,9 +2,15 @@ import { URLField, UnloadedModuleProps } from "@agility/nextjs"
 import { gql } from "@apollo/client"
 import { getAgilityGraphQLClient } from "lib/cms/getAgilityGraphQLClient"
 import { getContentItem } from "lib/cms/getContentItem"
-import { PartnerListingClient } from "./PartnerListing.client"
 import { ComboboItem } from "components/micro/FilterComboBox"
 import { getPartnerListing } from "lib/cms-content/getPartnerListing"
+import dynamic from "next/dynamic"
+
+// Defer the listing client (filter combobox + infinite-load list) until
+// after initial render — this module is always below the fold.
+const PartnerListingClient = dynamic(() =>
+	import("./PartnerListing.client").then((m) => m.PartnerListingClient)
+)
 
 interface IPartnerListing {
 	title?: string

--- a/components/agility-components/PartnerLogoListing/PartnerLogoListing.server.tsx
+++ b/components/agility-components/PartnerLogoListing/PartnerLogoListing.server.tsx
@@ -1,10 +1,14 @@
 import { UnloadedModuleProps, ImageField, ContentItem } from "@agility/nextjs"
 import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
-import { PartnerLogoListingClient } from "./PartnerLogoListing.client"
 import { sampleSize, shuffle } from "lodash"
 import { ThreeDashLine } from "components/micro/ThreeDashLine"
 import { IPartner } from "lib/types/IPartner"
+import dynamic from "next/dynamic"
+
+const PartnerLogoListingClient = dynamic(() =>
+	import("./PartnerLogoListing.client").then((m) => m.PartnerLogoListingClient)
+)
 
 export interface LogoItem {
 	title: string

--- a/components/agility-components/TestimonialCarousel/TestimonialCarousel.tsx
+++ b/components/agility-components/TestimonialCarousel/TestimonialCarousel.tsx
@@ -3,7 +3,12 @@ import { ContentItem } from "@agility/content-fetch"
 import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
 import { getContentList } from "lib/cms/getContentList"
-import { TestimonialCarouselClient, TestimonialItem } from "./TestimonialCarousel.client"
+import type { TestimonialItem } from "./TestimonialCarousel.client"
+import dynamic from "next/dynamic"
+
+const TestimonialCarouselClient = dynamic(() =>
+	import("./TestimonialCarousel.client").then((m) => m.TestimonialCarouselClient)
+)
 
 interface ICarouselTestimonial {
 	quote: string

--- a/components/agility-components/Testimonials/Testimonials.tsx
+++ b/components/agility-components/Testimonials/Testimonials.tsx
@@ -4,9 +4,14 @@ import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
 import { getContentList } from "lib/cms/getContentList"
 import { ICaseStudy } from "lib/types/ICaseStudy"
-import { TestimonialsClient, MinCaseStudy } from "./Testimonials.client"
+import type { MinCaseStudy } from "./Testimonials.client"
 import { stripHtml } from "lib/utils/strip-html"
 import { ITestimonial } from "lib/types/ITestimonial"
+import dynamic from "next/dynamic"
+
+const TestimonialsClient = dynamic(() =>
+	import("./Testimonials.client").then((m) => m.TestimonialsClient)
+)
 
 interface ITestimonials {
 	header?: string


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1528
Closes https://agilitycms.atlassian.net/browse/PROD-1529
Closes https://agilitycms.atlassian.net/browse/PROD-1530

## Summary
Converts every static `*Client` import that uses embla-carousel to `next/dynamic` so the carousel JS lives in async chunks rather than the synchronous bundle.

Addresses audit items #15 (CaseStudyRotator), #16 (PartnerListing), #17 (EventListing) plus a sprawl of similar issues uncovered during investigation:

- `CaseStudyRotator.tsx` (#15)
- `PartnerListing.tsx` (#16)
- `EventListing.server.tsx` (#17)
- `CaseStudyDetails.tsx` (was statically leaking `CaseStudyRotatorClient` AND `CaseStudyDetailRotator`)
- `PartnerDetails.tsx` (was leaking `CaseStudyDetailRotator`)
- `TestimonialCarousel.tsx`
- `Testimonials.tsx`
- `LogoListing.server.tsx`
- `LogoListingModule.server.tsx`
- `PartnerLogoListing.server.tsx`

## Honest framing on the headline metric
**Route-table First Load JS stays at 442 kB.** Embla is used by enough places that webpack's chunk-splitting puts it in a shared chunk preloaded for the catch-all `/[...slug]` route — which represents the worst-case across 1400+ pages.

For pages that don't actually render all carousel modules (most of them), the deferred chunks won't execute on the critical path — real-world **LCP / TBT** on those pages should improve even though the build's worst-case number doesn't.

A bigger win on the headline metric would require either:
- Custom `splitChunks` config to disable embla's preloading
- Replacing embla with a lighter shared dependency

## Why merge this anyway
- More correct lazy-loading patterns across the carousel components
- Pages without carousels see real benefit
- Sets the stage for future chunk-splitting work
- Zero behavioral risk — every change is a mechanical `static import → dynamic()` swap

## Test plan
- [x] Build completes cleanly.
- [x] Reviewer: load a page with each carousel type and confirm the carousel still renders + works (autoplay logos, testimonials rotator, case study rotator, partner logos, etc.)
