### PR TITLE
Render page-level scripts from Agility CMS for AEO/structured data

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -13,6 +13,7 @@ import { DateTime } from "luxon"
 import agilitySDK from "@agility/content-fetch"
 import { SitemapNode } from "lib/types/SitemapNode"
 import { getRichSnippet } from "lib/cms-content/getRichSnippet"
+import { getPageScripts } from "lib/cms-content/getPageScripts"
 
 export const revalidate = cacheConfig.pathRevalidateDuration
 export const dynamicParams = true
@@ -116,6 +117,14 @@ export default async function Page({ params }: PageProps) {
 
 	const renderTimeStr = DateTime.now().toISO()
 	const jsonLD = getRichSnippet(agilityData)
+	const pageScripts = getPageScripts(agilityData.page as any)
+
+	const renderScript = (s: ReturnType<typeof getPageScripts>["top"][number], i: number) =>
+		s.innerHTML ? (
+			<script key={i} type={s.type} dangerouslySetInnerHTML={{ __html: s.innerHTML }} />
+		) : s.src ? (
+			<script key={i} type={s.type} src={s.src} async={s.async} defer={s.defer} />
+		) : null
 
 	return (
 		<div
@@ -126,11 +135,13 @@ export default async function Page({ params }: PageProps) {
 				//include the rich snipped if we have one
 				<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLD }} />
 			)}
+			{pageScripts.top.map(renderScript)}
 			{AgilityPageTemplate && <AgilityPageTemplate {...agilityData} />}
 			{!AgilityPageTemplate && (
 				// if we don't have a template for this page, show an error
 				<InlineError message={`No template found for page template name: ${agilityData.pageTemplateName}`} />
 			)}
+			{pageScripts.bottom.map(renderScript)}
 			<div className="hidden">Rendered on: {renderTimeStr}</div>
 		</div>
 	)

--- a/lib/cms-content/getPageScripts.ts
+++ b/lib/cms-content/getPageScripts.ts
@@ -1,0 +1,57 @@
+import ReactHtmlParser from "html-react-parser"
+
+export interface CustomScript {
+	type?: string
+	src?: string
+	async?: boolean
+	defer?: boolean
+	innerHTML?: string
+}
+
+export interface PageScripts {
+	top: CustomScript[]
+	bottom: CustomScript[]
+}
+
+const parseScripts = (html: string | undefined | null): CustomScript[] => {
+	if (!html) return []
+
+	const parsed = ReactHtmlParser(html)
+	const items = Array.isArray(parsed) ? parsed : [parsed]
+
+	const scripts: CustomScript[] = []
+
+	for (const item of items) {
+		if (!item || typeof item === "string") continue
+		if ((item as JSX.Element).type !== "script") continue
+
+		const props = (item as JSX.Element).props || {}
+
+		// html-react-parser puts script content in dangerouslySetInnerHTML.__html, not children
+		const innerHTML: string | undefined = props.dangerouslySetInnerHTML?.__html
+
+		if (!innerHTML && !props.src) continue
+
+		scripts.push({
+			type: props.type,
+			src: props.src,
+			async: props.async,
+			defer: props.defer,
+			innerHTML,
+		})
+	}
+
+	return scripts
+}
+
+/**
+ * Extract <script> tags from the page-level "Scripts" CMS field. JSON-LD that marketing
+ * pastes for AEO/structured data flows through here. The `scripts` object on a page has
+ * `top` (rendered near the top of the body) and `bottom` (rendered near the end).
+ */
+export const getPageScripts = (page: { scripts?: { top?: string; bottom?: string } } | null | undefined): PageScripts => {
+	return {
+		top: parseScripts(page?.scripts?.top),
+		bottom: parseScripts(page?.scripts?.bottom),
+	}
+}


### PR DESCRIPTION
## Summary

The "Scripts" field on Agility CMS pages (`scripts.top` / `scripts.bottom`) was being fetched in the page object but never rendered. JSON-LD that the marketing team pasted into that field for AEO / structured data was silently dropped on every page.

## What changed

- New helper `lib/cms-content/getPageScripts.ts` parses the HTML in `page.scripts.top` / `page.scripts.bottom` and returns `<script>` tag descriptors (type, src, async, defer, innerHTML).
- `app/[...slug]/page.tsx` calls the helper and renders `top` scripts above the page content and `bottom` scripts after it. Since `app/page.tsx` re-exports from `[...slug]/page.tsx`, the homepage and every other page are covered.

## Why `<body>` instead of `<head>`

For JSON-LD / structured data, Google explicitly supports placement anywhere on the page, and Next.js's App Router documents the in-body pattern as the recommended approach (the Metadata API does not accept arbitrary script tags). This matches the existing `getRichSnippet` pattern already in this file.

## Test plan

1. Go to the preview link
2. When on the home page, view source on the page
3. search for "application/ld+json", ensure that you can find the objects that marketing has added to the home page [here](https://app.agilitycms.com/instance/80dc0987-be84-4405-a572-aba199832f68/en-ca/pages/page-548) (under the seo tab, find `Scripts included in <head>`)
