### PR TITLE
perf: tune Hero + SplitHero image sizes for LCP

### DIFF
--- a/components/agility-components/Hero/Hero.tsx
+++ b/components/agility-components/Hero/Hero.tsx
@@ -29,7 +29,8 @@ export const Hero = async ({ module, languageCode }: UnloadedModuleProps) => {
 			<link
 				rel="preload"
 				as="image"
-				href={`${fields.image.url}?format=auto&w=480`}
+				imageSrcSet={`${fields.image.url}?format=auto&w=400 400w, ${fields.image.url}?format=auto&w=480 480w, ${fields.image.url}?format=auto&w=800 800w, ${fields.image.url}?format=auto&w=960 960w`}
+				imageSizes="(min-width: 640px) 480px, 400px"
 				fetchPriority="high"
 			/>
 		)}
@@ -43,7 +44,16 @@ export const Hero = async ({ module, languageCode }: UnloadedModuleProps) => {
 
 				{fields.mediaType === "image" && fields.image && (
 					<div className="mb-10 flex w-full justify-center">
-						<AgilityPic image={fields.image} fallbackWidth={480} priority />
+						<AgilityPic
+							image={fields.image}
+							fallbackWidth={400}
+							priority
+							sources={[
+								{ media: "(min-width: 640px) and (min-resolution: 2x)", width: 960 },
+								{ media: "(min-width: 640px)", width: 480 },
+								{ media: "(min-resolution: 2x)", width: 800 },
+							]}
+						/>
 					</div>
 				)}
 

--- a/components/agility-components/SplitHero/SplitHero.tsx
+++ b/components/agility-components/SplitHero/SplitHero.tsx
@@ -83,12 +83,13 @@ export const SplitHero = async ({ module, languageCode }: UnloadedModuleProps) =
 						<AgilityPic
 							image={fields.image}
 							className="w-full"
-							fallbackWidth={600}
+							fallbackWidth={400}
 							priority
 							sources={[
 								{ media: "(min-width: 1200px)", width: 700 },
 								{ media: "(min-width: 768px)", width: 600 },
 								{ media: "(min-width: 640px)", width: 500 },
+								{ media: "(max-width: 639px)", width: 400 },
 							]}
 						/>
 					</div>


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1516
Closes https://agilitycms.atlassian.net/browse/PROD-1517
Closes https://agilitycms.atlassian.net/browse/PROD-1518

## Summary
Three related fixes to the hero LCP element:

**Hero.tsx** (audit #3 + #4):
- Add responsive `sources` to AgilityPic (retina + mobile breakpoints).
- Lower `fallbackWidth` 480 → 400 so mobile gets an appropriately-sized image instead of an oversized 480px one.
- Replace the fixed-size `<link rel="preload" href="...?w=480">` with `imageSrcSet` + `imageSizes` so the browser picks the right preload size for each viewport.

**SplitHero.tsx** (audit #5):
- Add a `(max-width: 639px)` source at width 400 to avoid mobile devices downloading the 600px desktop image.
- Lower `fallbackWidth` 600 → 400 for the no-picture-support fallback.

## Bundle impact
**Unchanged.** These are runtime image-fetching changes. The real wins show up in the Network tab on mobile + retina viewports as smaller image responses, and a more accurate preload that doesn't waste bytes on the wrong size.

## Test plan
- [x] Build completes cleanly (TypeScript accepts `imageSrcSet`/`imageSizes` on `<link>`).
- [ ] Reviewer: load a page with a Hero (image variant) on mobile + desktop:
  - DevTools → Network → confirm the requested image width matches viewport (mobile gets ~400px, desktop gets ~480px, retina desktop gets ~960px).
  - DevTools → Network → confirm the preload `<link>` in `<head>` and the actual `<img>` request resolve to the same URL (no wasted preload).
- [ ] Reviewer: load a page with a SplitHero on mobile (< 640px viewport) — confirm the image request is ~400px not 600px.
