### PR TITLE
perf: replace luxon with Intl.DateTimeFormat in client-tree components

### DIFF
--- a/components/agility-components/EventListing/EventCard.tsx
+++ b/components/agility-components/EventListing/EventCard.tsx
@@ -2,21 +2,30 @@ import { AgilityPic } from "@agility/nextjs"
 import { IconCalendar, IconCalendarCheck, IconClock, IconDeviceWatch } from "@tabler/icons-react"
 import { LinkButton } from "components/micro/LinkButton"
 import { IEventMin } from "lib/cms-content/getEventListing"
-import { DateTime } from "luxon"
 import Link from "next/link"
 
 interface Props {
 	event: IEventMin
 }
 
+// Formatters hoisted outside the component so they're constructed once per module.
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "2-digit",
+	year: "numeric"
+})
+const timeFormatter = new Intl.DateTimeFormat("en-US", {
+	hour: "numeric",
+	minute: "2-digit"
+})
+
 export const EventCard = ({ event }: Props) => {
 	const date = new Date(event.fields.date)
 	date.setHours(date.getHours() - 5)
-	const dt = DateTime.fromJSDate(date)
-	const dateStr = dt.toFormat("LLL dd, yyyy")
-	const timeStr = dt.toFormat("t")
+	const dateStr = dateFormatter.format(date)
+	const timeStr = timeFormatter.format(date)
 
-	const isPast = dt < DateTime.now()
+	const isPast = date < new Date()
 	const url = `/resources/events/${event.fields.uRL}`
 	return (
 		<div className="mt-10 flex flex-col items-center gap-5 lg:flex-row">
@@ -27,7 +36,7 @@ export const EventCard = ({ event }: Props) => {
 			</Link>
 			<div className="flex flex-col gap-3 text-center lg:w-1/2 lg:text-left">
 				<h3 className="text-3xl font-medium">{event.fields.title}</h3>
-				<time dateTime={dt.toISO()} className="flex gap-3">
+				<time dateTime={date.toISOString()} className="flex gap-3">
 					<div className="flex items-center gap-1">
 						<IconCalendarCheck size={24} className="text-slate-500" />
 						<div className="font-medium">{dateStr}</div>

--- a/components/agility-components/ReviewRotator/ReviewItem.tsx
+++ b/components/agility-components/ReviewRotator/ReviewItem.tsx
@@ -5,8 +5,13 @@ import { IReview } from "./ReviewRotator"
 import { ContentItem } from "@agility/content-fetch"
 import { useState } from "react"
 import clsx from "clsx"
-import { DateTime } from "luxon"
 import { renderHTMLCustom } from "lib/utils/renderHtmlCustom"
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "2-digit",
+	year: "numeric"
+})
 
 export const ReviewItem = ({
 	review,
@@ -20,7 +25,7 @@ export const ReviewItem = ({
 	const [isExpanded, setIsExpanded] = useState(false)
 
 	const d = new Date(review.fields.reviewDate)
-	const dtStr = DateTime.fromJSDate(d).toFormat("LLL dd, yyyy")
+	const dtStr = dateFormatter.format(d)
 
 	return (
 		<div className="flex flex-col gap-2 rounded-md border border-background p-5">


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1545

## Summary
Two components were doing trivial date formatting via Luxon's `DateTime` and dragging the lib (~75 KB raw) into the synchronous client bundle:

- **`EventCard.tsx`** — rendered by `EventListing.client.tsx` (transitive client). Used `DateTime.fromJSDate(d).toFormat("LLL dd, yyyy")` and `toFormat("t")`.
- **`ReviewItem.tsx`** — `'use client'` directly. Same pattern.

Both are now formatted via `Intl.DateTimeFormat` instances hoisted to module scope (constructed once, reused per render). Output is identical (`Jan 05, 2026`, `3:45 PM`). The `isPast` comparison uses native `Date`.

## Bundle impact
**Per-route First Load JS: 442 kB → 423 kB (-19 kB gzipped).**

Chunk 993 (228K with Luxon) shrank to chunk 499 (168K without). Verified 0 Luxon signatures in any client chunk after the swap.

## Server-side stays
This only swaps the **two client-tree** call sites. Server-side code (`lib/cms-content/*`, `app/[...slug]/page.tsx`, `PostDetails.tsx`, `EventDetails.tsx`, etc.) keeps Luxon since it has nicer APIs and never ships to the client.


## Test plan
- [x] Build completes cleanly; route table shows 423 kB First Load JS.
- [x] Zero Luxon signatures (`fromISO`, `toFormat`, `fromJSDate`) in any client chunk.
- [ ] Reviewer: load a page using `EventListing` and a page using `ReviewRotator`; confirm dates render the same way as before (`Jan 05, 2026`, `3:45 PM`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)