### PR TITLE
chore: remove unused string-strip-html dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"react-highlight-words": "^0.21.0",
-		"string-strip-html": "^12.0.0",
 		"typescript": "^5.5.3"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,11 +4077,6 @@ html-dom-parser@3.1.2:
     domhandler "5.0.3"
     htmlparser2 "8.0.1"
 
-html-entities@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz"
-  integrity sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==
-
 html-react-parser@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.4.tgz"
@@ -4814,11 +4809,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
-  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
-
 lodash.eq@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/lodash.eq/-/lodash.eq-4.0.0.tgz"
@@ -4829,11 +4819,6 @@ lodash.indexof@^4.0.5:
   resolved "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz"
   integrity sha512-t9wLWMQsawdVmf6/IcAgVGqAJkNzYVcn4BHYZKTPW//l7N5Oq7Bq138BaVk19agcsPZePcidSgTTw4NqS1nUAw==
 
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
-  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
@@ -4843,16 +4828,6 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
-
-lodash.trim@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz"
-  integrity sha512-nJAlRl/K+eiOehWKDzoBVrSMhK0K3A3YQsUNXHQa5yIrKBAhsZgSu3KoAFoFT+mEgiyBHddZ0pRk1ITpIp90Wg==
-
-lodash.without@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz"
-  integrity sha512-M3MefBwfDhgKgINVuBJCO1YR3+gf6s9HNJsIiZ/Ru77Ws6uTb9eBuvrkpzO+9iLoAaRodGuq7tyrPCx+74QYGQ==
 
 lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
   version "4.17.21"
@@ -5614,35 +5589,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-ranges-apply@^6.2.12:
-  version "6.2.12"
-  resolved "https://registry.npmjs.org/ranges-apply/-/ranges-apply-6.2.12.tgz"
-  integrity sha512-kvbXY6BNDpEAri/PlDZHlDyEAFvbAlfHGcIPQ6lg2BCifepx0t7knULy0ryvtsDuYCutK2ZVp+XTCMWcfaf/AQ==
-  dependencies:
-    ranges-merge "^8.2.7"
-    tiny-invariant "^1.3.1"
-
-ranges-merge@^8.2.7:
-  version "8.2.7"
-  resolved "https://registry.npmjs.org/ranges-merge/-/ranges-merge-8.2.7.tgz"
-  integrity sha512-ymJfok6pW4vndF8wy6SeqnLGu5GH8k+MM+W4fAqif79HGNloNzwE0ijVmuRd8D7ulJnwo5BGzwpZpXYHYeLlMQ==
-  dependencies:
-    ranges-push "^6.2.7"
-    ranges-sort "^5.1.6"
-
-ranges-push@^6.2.7:
-  version "6.2.7"
-  resolved "https://registry.npmjs.org/ranges-push/-/ranges-push-6.2.7.tgz"
-  integrity sha512-OX12airFLYK4/6dh3b82NRtGzpXyOWTmjiJzD/oMvzgZ2cfNbsa5qKLtf9AwZO6cVOpS2Li1l2mKTVjlM6MMpg==
-  dependencies:
-    string-collapse-leading-whitespace "^6.1.7"
-    string-trim-spaces-only "^4.1.6"
-
-ranges-sort@^5.1.6:
-  version "5.1.6"
-  resolved "https://registry.npmjs.org/ranges-sort/-/ranges-sort-5.1.6.tgz"
-  integrity sha512-/Mlg0Oe5iwu2lxeZGG/zzz92rQ6LpKimMx9uBj4EQthSSUDpvNeQzMthhdDBi/NGhG29rIWGpgl9jUHomUmX3Q==
-
 react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
@@ -6131,41 +6077,10 @@ streamsearch@^1.1.0:
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-string-collapse-leading-whitespace@^6.1.7:
-  version "6.1.7"
-  resolved "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-6.1.7.tgz"
-  integrity sha512-RGpJrs/C31mPyBPvmjcM16joFYaywAoJ8L9pWY/xFegkykFdMrg569ragafoJZgv485hEwWjihD5VgwJftrRmw==
-
 string-env-interpolation@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz"
   integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
-
-string-left-right@^5.1.7:
-  version "5.1.7"
-  resolved "https://registry.npmjs.org/string-left-right/-/string-left-right-5.1.7.tgz"
-  integrity sha512-WSFZJ/oy3Ako6VS3+MyA7S1OceG+RIFkPUQzHumtw/N8aAA5WafVgQg2AE9WQWZ7py9bJlcH50BjSo+PlN8xNw==
-  dependencies:
-    lodash.clonedeep "^4.5.0"
-    lodash.isplainobject "^4.0.6"
-
-string-strip-html@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.npmjs.org/string-strip-html/-/string-strip-html-12.0.0.tgz"
-  integrity sha512-Ojx1qfh7zViiRhIUCtZoIWxtJbFCCy/VdamDBt0MOpERRb4ZDNzUAzdz8zbXihnTKqHdm/9rT12JHiMdI+2eGA==
-  dependencies:
-    html-entities "^2.3.3"
-    lodash.isplainobject "^4.0.6"
-    lodash.trim "^4.5.1"
-    lodash.without "^4.4.0"
-    ranges-apply "^6.2.12"
-    ranges-push "^6.2.7"
-    string-left-right "^5.1.7"
-
-string-trim-spaces-only@^4.1.6:
-  version "4.1.6"
-  resolved "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-4.1.6.tgz"
-  integrity sha512-rI++1I1wesrddwz1TH011+zNO0k+0u4b8RwDrzPlrQ3jvPrmrXfn5O5eWeLFuV/8zmPSXe5iq+G43hURZF89hQ==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
@@ -6358,11 +6273,6 @@ through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
-
-tiny-invariant@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz"
-  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
 
 title-case@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-1546

## Summary
Audit (#33) confirmed `string-strip-html` is unused — `lib/utils/strip-html.ts` uses a regex + `he` (HTML entities lib), not this package. Removing dead weight from `package.json`.

Also verified `html-react-parser` doesn't leak to the client bundle (zero signatures in any client chunk; only imported by server-only files in `lib/cms-content/`).

## Impact
**No runtime bundle change** — the package was already excluded from the client bundle because nothing imported it. Win is in:
- Lighter `yarn install` (204 KB less in `node_modules`)
- Cleaner `package.json` (no dead-weight entries to confuse future devs)

## Test plan
- [x] Build completes cleanly.
