### PR TITLE
chore: remove silently-no-op optimizeCss + critters

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,7 @@ const nextConfig = {
 	//output: "standalone", //this is only for next.js on Azure Static Web Apps...
 	experimental: {
 		// one year in seconds for the stale-while-revalidate cache-control
-		swrDelta: 31536000,
-		optimizeCss: true
+		swrDelta: 31536000
 	},
 
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "bloom-filters": "^3.0.2",
     "cheerio": "^1.0.0",
     "concurrently": "^8.2.2",
-    "critters": "^0.0.25",
     "dotenv": "^16.4.5",
     "graphql": "^16.9.0",
     "he": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,19 +2842,6 @@ cosmiconfig@^8.1.0, cosmiconfig@^8.1.3:
     parse-json "^5.2.0"
     path-type "^4.0.0"
 
-critters@^0.0.25:
-  version "0.0.25"
-  resolved "https://registry.npmjs.org/critters/-/critters-0.0.25.tgz"
-  integrity sha512-ROF/tjJyyRdM8/6W0VqoN5Ql05xAGnkf5b7f3sTEl1bI5jTQQf8O918RD/V9tEb9pRY/TKcvJekDbJtniHyPtQ==
-  dependencies:
-    chalk "^4.1.0"
-    css-select "^5.1.0"
-    dom-serializer "^2.0.0"
-    domhandler "^5.0.2"
-    htmlparser2 "^8.0.2"
-    postcss "^8.4.23"
-    postcss-media-query-parser "^0.2.3"
-
 cross-fetch@^3.1.5:
   version "3.1.8"
   resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz"
@@ -3207,7 +3194,7 @@ entities@^4.2.0, entities@^4.3.0:
   resolved "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
-entities@^4.4.0, entities@^4.5.0:
+entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -4126,16 +4113,6 @@ htmlparser2@8.0.1:
     domhandler "^5.0.2"
     domutils "^3.0.1"
     entities "^4.3.0"
-
-htmlparser2@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz"
-  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
-    domutils "^3.0.1"
-    entities "^4.4.0"
 
 htmlparser2@^9.1.0:
   version "9.1.0"
@@ -5533,11 +5510,6 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-postcss-media-query-parser@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz"
-  integrity sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==
-
 postcss-selector-parser@6.0.10:
   version "6.0.10"
   resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz"
@@ -5551,7 +5523,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@^8.4.23:
+postcss@8.4.31:
   version "8.4.31"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
   integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==


### PR DESCRIPTION
## Summary
Audit (#21) verified that `experimental.optimizeCss: true` was doing absolutely nothing in this codebase. Removing the flag + the (now-unused) `critters` dependency.

## How I verified

With `optimizeCss: true` enabled, the rendered `<head>` contained:
- **Zero** inline `<style>` tags (critical CSS not inlined)
- **Three** standard `<link rel="stylesheet">` tags (no deferred-load pattern like `media="print" onload="this.media='all'"`)

Rebuilding with the flag removed produced **byte-identical CSS files** (1814 + 174265 + 11616 bytes, same hashes). Pure no-op.

Likely cause: `critters@0.0.25` (the version Next 14.2 ships) doesn't handle Tailwind v4's CSS structure correctly. Known issue across several frameworks.

## What this means for perf

The intended LCP win from critical-CSS inlining is **unrealized** — 174 KB of CSS is still render-blocking on every page. Re-enabling would need:
- Upgrade Next.js 15 (different CSS pipeline)
- OR switch to `beasties` (the maintained critters fork) via a custom build step
- OR manually extract critical CSS at build time

Captured as a follow-up in `PERFORMANCE_AUDIT.md`.

## Bundle impact
- No change to JS bundle.
- No change to CSS output (already confirmed byte-identical).
- `critters` removed from `node_modules` (small `yarn install` improvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)