### PR TITLE
Sanitize non-ASCII whitespace in JSON-LD page scripts

### DIFF
--- a/lib/cms-content/getPageScripts.ts
+++ b/lib/cms-content/getPageScripts.ts
@@ -28,9 +28,16 @@ const parseScripts = (html: string | undefined | null): CustomScript[] => {
 		const props = (item as JSX.Element).props || {}
 
 		// html-react-parser puts script content in dangerouslySetInnerHTML.__html, not children
-		const innerHTML: string | undefined = props.dangerouslySetInnerHTML?.__html
+		let innerHTML: string | undefined = props.dangerouslySetInnerHTML?.__html
 
 		if (!innerHTML && !props.src) continue
+
+		// JSON parsers (RFC 8259) only accept ASCII whitespace. Marketers pasting JSON-LD
+		// from Word/Docs/Notion sometimes bring U+00A0 / U+2028 / U+2029, which Google
+		// Search Console rejects with "Missing '}' or object member name".
+		if (innerHTML && props.type === "application/ld+json") {
+			innerHTML = innerHTML.replace(/[\u00A0\u2028\u2029]/g, " ")
+		}
 
 		scripts.push({
 			type: props.type,


### PR DESCRIPTION
## Summary
- Strip U+00A0, U+2028, and U+2029 from `application/ld+json` script bodies in `getPageScripts.ts` before they're rendered to the page.
- These characters get introduced when marketers paste JSON-LD into the CMS Scripts field from rich-text sources (Word, Docs, Notion). JSON parsers per RFC 8259 only accept ASCII whitespace, so Google Search Console rejects the structured data with: `Parsing error: Missing '}' or object member name`.
- Scoped to `application/ld+json` only — other script types (analytics, embeds) are untouched.

## Context
A Search Console error was forwarded today flagging the homepage's Organization / FAQPage / SoftwareApplication JSON-LD. Inspecting the live HTML showed 26 / 296 / 28 non-breaking-space characters respectively across those three blocks. The CMS source has been cleaned up manually; this change is the belt-and-suspenders fix so a future contaminated paste still produces valid markup.

## Test plan
- [x] `tsc --noEmit` passes
