### PR TITLE
Render RightORLeftContentModule heading as H1 by default

### DIFF
--- a/components/agility-components/RightORLeftContentModule/RightORLeftContentModule.tsx
+++ b/components/agility-components/RightORLeftContentModule/RightORLeftContentModule.tsx
@@ -35,6 +35,7 @@ interface IRightORLeftContentModule {
 	video?: string // JSON string from Vimeo field
 	darkMode?: string
 	breadcrumb?: string
+	useH2ForHeading?: string
 }
 
 const RightORLeftContentModule = async ({ module, languageCode }: UnloadedModuleProps) => {
@@ -50,6 +51,9 @@ const RightORLeftContentModule = async ({ module, languageCode }: UnloadedModule
 	const { cTA1Optional, cTA2Optional, description, graphic, textSide, title, breadcrumb, video } = fields
 
 	const darkMode = fields.darkMode === "true"
+
+	// Render the title as an H1 by default; use an H2 only when the editor opts in.
+	const HeadingTag = fields.useH2ForHeading === "true" ? "h2" : "h1"
 
 	// Parse Vimeo video data if present
 	let vimeoVideoData: VimeoVideoData | null = null
@@ -104,7 +108,7 @@ const RightORLeftContentModule = async ({ module, languageCode }: UnloadedModule
 				</div>
 				<div className="flex-1">
 					{breadcrumb && <div className={clsx("mb-2 text-sm font-semibold", darkMode ? "text-gray-400" : "text-gray-600")}>{breadcrumb}</div>}
-					<h2 className="text-balance text-5xl font-medium leading-[1.15]">{title}</h2>
+					<HeadingTag className="text-balance text-5xl font-medium leading-[1.15]">{title}</HeadingTag>
 					{description && (
 						<div
 							className={clsx("prose mt-5 max-w-none", darkMode ? "prose-invert" : "")}


### PR DESCRIPTION
## What

The **Right OR Left Content** module hardcoded its title as an `<h2>`. In most placements this module's title is the main heading of the section/page, so it should be an `<h1>`.

This change:
- Renders the title as an `<h1>` by **default**.
- Falls back to `<h2>` only when the editor checks a new **"Use H2 for Heading"** toggle on the component model (useful when the page already has an H1 elsewhere).

## CMS changes

Added a new Boolean field to the `RightORLeftContentModule` component model in Agility (instance: *Agility CMS Website - 2021*):
- **Label:** Use H2 for Heading
- **Reference name:** `UseH2ForHeading`
- **Unchecked by default** → H1 is the default.

## Code changes

- Added `useH2ForHeading?: string` to the `IRightORLeftContentModule` interface.
- `const HeadingTag = fields.useH2ForHeading === "true" ? "h2" : "h1"` (defaults to H1).
- Swapped the hardcoded `<h2>` for `<HeadingTag>`, preserving existing styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
