### PR TITLE
LCP fixes: hero image priority signals, matched preloads, CDN preconnect

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,7 +51,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 				<link rel="preconnect" href="https://forms.hsforms.com" />
 				<link rel="preconnect" href="https://www.googletagmanager.com" />
 				<link rel="dns-prefetch" href="https://unpkg.com" />
-				<link rel="dns-prefetch" href="https://cdn.aglty.io" />
+				{/* LCP images are served from cdn.aglty.io — preconnect (not just dns-prefetch)
+				    so the TCP+TLS handshake is off the LCP critical path */}
+				<link rel="preconnect" href="https://cdn.aglty.io" />
 			</head>
 			<body data-agility-guid={process.env.AGILITY_GUID}>
 				{/* GTM loaded with lazyOnload strategy to defer until after page interactive */}

--- a/components/agility-components/Hero/Hero.tsx
+++ b/components/agility-components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
-import { AgilityPic, ImageField, UnloadedModuleProps, URLField } from "@agility/nextjs"
+import { ImageField, UnloadedModuleProps, URLField } from "@agility/nextjs"
+import { AgilityPic } from "components/common/AgilityPic"
 import { Container } from "components/micro/Container"
 import { LinkButton } from "components/micro/LinkButton"
 import { getContentItem } from "lib/cms/getContentItem"

--- a/components/agility-components/PostDetails.tsx
+++ b/components/agility-components/PostDetails.tsx
@@ -75,17 +75,52 @@ const PostDetails = async ({ dynamicPageItem }: UnloadedModuleProps) => {
 	// format date
 	const dateStr = DateTime.fromJSDate(new Date(post.date)).toFormat("LLL. dd, yyyy")
 
+	// Preload URLs must byte-match the <picture> sources, which cap the requested
+	// width at the original image width (see AgilityPic)
+	const preloadUrl = (w: number) => {
+		if (!post.postImage) return ""
+		return `${post.postImage.url}?format=auto&w=${post.postImage.width > 0 ? Math.min(w, post.postImage.width) : w}`
+	}
+
 	return (
 		<>
-		{/* Hoist a preload hint for the hero image so the browser fetches it before
-		    parsing down to the <picture> element — the primary LCP fix for /blog/* */}
+		{/* Hoist preload hints for the hero image so the browser fetches it before
+		    parsing down to the <picture> element — the primary LCP fix for /blog/*.
+		    Each link's media query mirrors the <picture> source that device will
+		    actually select, so the preload is never wasted. Mid-range breakpoints
+		    (640-1199px) are intentionally uncovered — small traffic share. */}
 		{post.postImage && (
-			<link
-				rel="preload"
-				as="image"
-				href={`${post.postImage.url}?format=auto&w=800`}
-				fetchPriority="high"
-			/>
+			<>
+				<link
+					rel="preload"
+					as="image"
+					href={preloadUrl(640)}
+					media="(max-width: 639px) and (min-resolution: 2x)"
+					fetchPriority="high"
+				/>
+				{/* mobile 1x devices fall through to the fallback <img>, whose URL is not width-capped */}
+				<link
+					rel="preload"
+					as="image"
+					href={`${post.postImage.url}?format=auto&w=800`}
+					media="(max-width: 639px) and (max-resolution: 1.9x)"
+					fetchPriority="high"
+				/>
+				<link
+					rel="preload"
+					as="image"
+					href={preloadUrl(1600)}
+					media="(min-width: 1200px) and (min-resolution: 2x)"
+					fetchPriority="high"
+				/>
+				<link
+					rel="preload"
+					as="image"
+					href={preloadUrl(800)}
+					media="(min-width: 1200px) and (max-resolution: 1.9x)"
+					fetchPriority="high"
+				/>
+			</>
 		)}
 		<Container >
 			<article className="mx-auto max-w-7xl">

--- a/components/agility-components/SplashImage/SplashImage.tsx
+++ b/components/agility-components/SplashImage/SplashImage.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { AgilityPic, ImageField, UnloadedModuleProps } from "@agility/nextjs"
+import { ImageField, UnloadedModuleProps } from "@agility/nextjs"
+import { AgilityPic } from "components/common/AgilityPic"
 
 import { getContentItem } from "lib/cms/getContentItem"
 
@@ -17,10 +18,9 @@ export const SplashImage = async ({ module, languageCode }: UnloadedModuleProps)
 		<div data-agility-component={contentID} >
 			<div className="mx-auto max-w-7xl">
 				{fields.splashImage && (
-					<div className="flex w-full justify-center">
+					<div className="flex w-full justify-center" data-agility-field="splashImage">
 						<AgilityPic
 							image={fields.splashImage}
-							data-agility-field="splashImage"
 							fallbackWidth={400}
 							priority
 							className="w-full"

--- a/components/agility-components/SplitHero/SplitHero.tsx
+++ b/components/agility-components/SplitHero/SplitHero.tsx
@@ -1,4 +1,5 @@
-import { AgilityPic, ImageField, UnloadedModuleProps, URLField } from "@agility/nextjs"
+import { ImageField, UnloadedModuleProps, URLField } from "@agility/nextjs"
+import { AgilityPic } from "components/common/AgilityPic"
 import { Container } from "components/micro/Container"
 import { LinkButton } from "components/micro/LinkButton"
 import { getContentItem } from "lib/cms/getContentItem"
@@ -22,6 +23,11 @@ export const SplitHero = async ({ module, languageCode }: UnloadedModuleProps) =
 		languageCode,
 	})
 
+	// Preload URLs must byte-match the <picture> sources, which cap the requested
+	// width at the original image width (see AgilityPic)
+	const preloadUrl = (w: number) =>
+		`${fields.image.url}?format=auto&w=${fields.image.width > 0 ? Math.min(w, fields.image.width) : w}`
+
 	// Build cycling words from up to 4 highlighted heading fields
 	const cyclingWords = [
 		fields.highlightedHeading,
@@ -31,6 +37,42 @@ export const SplitHero = async ({ module, languageCode }: UnloadedModuleProps) =
 	].filter((w): w is string => !!w && w.trim().length > 0)
 
 	return (
+		<>
+		{/* Hoist preload hints so the hero image starts fetching before the parser
+		    reaches the <picture> element. Each media query mirrors the matching
+		    <picture> source below, so the preloaded file is the one actually used. */}
+		{fields.image && (
+			<>
+				<link
+					rel="preload"
+					as="image"
+					href={preloadUrl(400)}
+					media="(max-width: 639px)"
+					fetchPriority="high"
+				/>
+				<link
+					rel="preload"
+					as="image"
+					href={preloadUrl(500)}
+					media="(min-width: 640px) and (max-width: 767px)"
+					fetchPriority="high"
+				/>
+				<link
+					rel="preload"
+					as="image"
+					href={preloadUrl(600)}
+					media="(min-width: 768px) and (max-width: 1199px)"
+					fetchPriority="high"
+				/>
+				<link
+					rel="preload"
+					as="image"
+					href={preloadUrl(700)}
+					media="(min-width: 1200px)"
+					fetchPriority="high"
+				/>
+			</>
+		)}
 		<Container id={`${contentID}`} data-agility-component={contentID} className="relative overflow-hidden">
 			{/* Subtle purple gradient wash */}
 			<div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-purple-50 via-white to-purple-50/50" />
@@ -96,5 +138,6 @@ export const SplitHero = async ({ module, languageCode }: UnloadedModuleProps) =
 				)}
 			</div>
 		</Container>
+		</>
 	)
 }

--- a/components/agility-components/TextBlockWithImage.tsx
+++ b/components/agility-components/TextBlockWithImage.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import {
-	AgilityPic,
 	ContentItem,
 	ImageField,
 	Module,
@@ -8,6 +7,7 @@ import {
 	UnloadedModule,
 	UnloadedModuleProps
 } from "@agility/nextjs"
+import { AgilityPic } from "components/common/AgilityPic"
 import Link from "next/link"
 import getAgilitySDK from "lib/cms/getAgilitySDK"
 import { getContentItem } from "lib/cms/getContentItem"
@@ -27,7 +27,7 @@ interface ITextBlockWithImage {
  * @param param0
  * @returns
  */
-const TextBlockWithImage = async ({ module, languageCode }: UnloadedModuleProps) => {
+const TextBlockWithImage = async ({ module, languageCode, page }: UnloadedModuleProps) => {
 	const { fields, contentID } = await getContentItem<ITextBlockWithImage>({
 		contentID: module.contentid,
 		languageCode
@@ -67,8 +67,13 @@ const TextBlockWithImage = async ({ module, languageCode }: UnloadedModuleProps)
 		}
 	}
 
-	//determine if the image should be high priority
-	const priority = fields.highPriority === "true"
+	//determine if the image should be high priority: either the CMS field is set,
+	//or this is the first module in its content zone (likely above the fold / the LCP image)
+	const isFirstModuleInZone = Object.values(page?.zones ?? {}).some((zoneModules: any) => {
+		const firstItem = zoneModules?.[0]?.item
+		return (firstItem?.contentid ?? firstItem?.contentID) === module.contentid
+	})
+	const priority = fields.highPriority === "true" || isFirstModuleInZone
 
 	return (
 		<div className="relative px-8" data-agility-component={contentID}>


### PR DESCRIPTION
## Context

Google Search Console flags LCP > 2.5s on mobile for a majority of pages. A code audit traced this to above-the-fold images shipping with no browser priority signal, a mismatched preload on blog posts, and a missing preconnect. This PR implements the 5 LCP fixes from that audit (INP fixes follow in a separate branch).

## Changes

### 1. Hero components now use the local `AgilityPic` (fetchPriority + dimensions)
There are two `AgilityPic` implementations. The local `components/common/AgilityPic.tsx` emits `fetchPriority="high"` + `loading="eager"` and `width`/`height` when `priority` is set; the `@agility/nextjs` package version only toggles `loading` — it never emits `fetchPriority` or dimensions, so the `priority` prop on every hero was silently half-ignored. `Hero`, `SplitHero`, `SplashImage`, and `TextBlockWithImage` now import the local component. Verified: hero `<img>` tags now render `fetchPriority="high" width=... height=...`.

### 2. `TextBlockWithImage` auto-prioritizes when it's the first module on the page
Previously `priority` was only set when the `highPriority` CMS field was `"true"` — if an editor placed this module first on a page without setting the field, the LCP image rendered `loading="lazy"`. The component now also detects (via `page.zones`) whether it is the first module in its content zone and prioritizes automatically. The CMS field still works as a manual override.

### 3. Blog post preload now matches what mobile actually downloads
`PostDetails` preloaded the featured image at `w=800`, but the `<picture>` serves `w=640` to 2x phones — the preload downloaded a wasted image AND the real LCP image wasn't preloaded. Replaced with media-scoped preload links that mirror the `<picture>` source selection exactly (mobile 2x → 640, mobile 1x → 800, desktop ≥1200px → 800 / 1600 for 2x), including AgilityPic's width-capping behavior so URLs byte-match for cache hits.

### 4. `SplitHero` (homepage hero) gets preload hints
`Hero.tsx` already hoists a `<link rel="preload" as="image" fetchPriority="high">`; SplitHero didn't — combined with #1, the homepage hero image had zero priority signal. Added media-scoped preloads mirroring its source ladder (400/500/600/700w by breakpoint).

### 5. `preconnect` to the image CDN
`cdn.aglty.io` only had `dns-prefetch`; upgraded to `preconnect` so the TCP+TLS handshake is off the LCP critical path. Note from verification: current homepage/blog LCP images are actually served from `static.agilitycms.com` (which already had a preconnect), so this mainly benefits pages with `cdn.aglty.io` assets.

## Verification

Ran the dev server against the live CMS and inspected rendered HTML:
- Homepage: 4 SplitHero preloads present with mutually exclusive media queries; hero `<img>` has `loading="eager" fetchPriority="high" width="400" height="400"`.
- Blog post: 4 media-scoped preloads byte-matching the `<picture>` sources; featured image has `fetchPriority="high" width="800" height="450"`.
- Swept ~92 sitemap pages after the import swaps: no render regressions (`/product/why-agility` 301s via pre-existing middleware redirect).
- `tsc --noEmit` clean.
