### PR TITLE
INP fixes: defer GTM, passive scroll handler, lighter client bundles

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import SiteFooter from "components/common/footer/SiteFooter"
 import SiteHeader from "components/common/header/SiteHeader"
 
 import { useAgilityContext } from "lib/cms/useAgilityContext"
-import { GoogleTagManager } from "@next/third-parties/google"
 
 import "/styles/output.css"
 
@@ -54,8 +53,15 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 				<link rel="dns-prefetch" href="https://cdn.aglty.io" />
 			</head>
 			<body data-agility-guid={process.env.AGILITY_GUID}>
-				{/* GTM loaded with lazyOnload strategy to defer until after page interactive */}
-				{process.env.GTM_ID && <GoogleTagManager gtmId={process.env.GTM_ID} />}
+				{/* GTM via a hand-rolled lazyOnload snippet: the @next/third-parties
+				    GoogleTagManager component always injects afterInteractive (it accepts
+				    no strategy prop), which puts ~2MB of downstream tag JS on the main
+				    thread during the critical window. lazyOnload waits for window.load. */}
+				{process.env.GTM_ID && (
+					<Script id="gtm" strategy="lazyOnload">
+						{`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${process.env.GTM_ID}');`}
+					</Script>
+				)}
 				<PostHogProvider>
 					<div id="site-wrapper">
 						<div id="site">

--- a/components/agility-components/G2CrowdReviewListing/G2CrowdReviewListing.client.tsx
+++ b/components/agility-components/G2CrowdReviewListing/G2CrowdReviewListing.client.tsx
@@ -2,7 +2,7 @@
 import Script from "next/script"
 import { IG2CrowdReviewListing } from "./G2CrowdReviewListing"
 import { useId, useRef } from "react"
-import { set } from "lodash"
+import set from "lodash/set"
 
 export const G2CrowdReviewListingClient = ({
 	gartnerSourcingLink,

--- a/components/agility-components/Pricing/PricingPackagesModule.client.tsx
+++ b/components/agility-components/Pricing/PricingPackagesModule.client.tsx
@@ -12,7 +12,7 @@ import {
 	IconSquareCheckFilled,
 	IconStarFilled
 } from "@tabler/icons-react"
-import { entries } from "lodash"
+import entries from "lodash/entries"
 
 import clsx from "clsx"
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/react"

--- a/components/agility-components/SingleTestimonialPanel.tsx
+++ b/components/agility-components/SingleTestimonialPanel.tsx
@@ -3,7 +3,7 @@ import { ContentItem } from "@agility/content-fetch"
 import { Container } from "components/micro/Container"
 import { getContentItem } from "lib/cms/getContentItem"
 import { ITestimonial } from "lib/types/ITestimonial"
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 import { LinkButton } from "components/micro/LinkButton"
 
 interface ISingleTestimonialPanel {

--- a/components/agility-components/SplitHero/SplitHero.client.tsx
+++ b/components/agility-components/SplitHero/SplitHero.client.tsx
@@ -27,8 +27,28 @@ export const CyclingHeading = ({ words, heading }: Props) => {
 
 	useEffect(() => {
 		if (words.length <= 1) return
-		const interval = setInterval(cycle, 3000)
-		return () => clearInterval(interval)
+		//respect reduced-motion preferences and pause the repeating main-thread
+		//work while the tab is hidden
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
+
+		let interval: ReturnType<typeof setInterval> | undefined
+		const start = () => {
+			if (!interval) interval = setInterval(cycle, 3000)
+		}
+		const stop = () => {
+			if (interval) {
+				clearInterval(interval)
+				interval = undefined
+			}
+		}
+		const onVisibilityChange = () => (document.hidden ? stop() : start())
+		document.addEventListener("visibilitychange", onVisibilityChange)
+		onVisibilityChange()
+
+		return () => {
+			stop()
+			document.removeEventListener("visibilitychange", onVisibilityChange)
+		}
 	}, [cycle, words.length])
 
 	const getTransformStyle = (): React.CSSProperties => {

--- a/components/common/header/SiteHeader.tsx
+++ b/components/common/header/SiteHeader.tsx
@@ -35,14 +35,13 @@ const SiteHeader = ({ headerContent: { header, links, preheaderLinks } }: Props)
 	 * Keep track of whether the user has scrolled so we can show a shadow on the header
 	 */
 	useEffect(() => {
-		const scrollHandler = (e: Event) => {
-			if (window.scrollY > 0) {
-				setIsScrolled(true)
-			} else {
-				setIsScrolled(false)
-			}
+		const scrollHandler = () => {
+			const scrolled = window.scrollY > 0
+			setIsScrolled((prev) => (prev === scrolled ? prev : scrolled))
 		}
-		window.addEventListener("scroll", scrollHandler)
+		//sync with a restored scroll position on load
+		scrollHandler()
+		window.addEventListener("scroll", scrollHandler, { passive: true })
 
 		return () => {
 			window.removeEventListener("scroll", scrollHandler)

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,10 @@ const nextConfig = {
 	experimental: {
 		// one year in seconds for the stale-while-revalidate cache-control
 		swrDelta: 31536000,
-		optimizeCss: true
+		optimizeCss: true,
+		// guarantee per-icon/per-component tree-shaking instead of relying on
+		// Next's implicit default list
+		optimizePackageImports: ['@tabler/icons-react', '@headlessui/react']
 	},
 
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,22 @@
+export {}
+
+/**
+ * Third-party globals injected by external scripts.
+ *
+ * These were previously typed (accidentally) by @next/third-parties, whose
+ * types declare a `[key: string]: any` index signature on Window. Now that
+ * GTM is loaded via a plain script snippet instead of that package's
+ * component, the globals the codebase actually uses are declared here.
+ */
+declare global {
+	interface Window {
+		/** Google Tag Manager data layer */
+		dataLayer?: Object[]
+		/** HubSpot forms embed API (js.hsforms.net) */
+		hbspt?: any
+		/** HubSpot tracking queue (js.hs-scripts.com) */
+		_hsq?: any[]
+		/** Gartner Peer Insights / G2 review widget */
+		GartnerPI_Widget?: any
+	}
+}


### PR DESCRIPTION
## Context

Google Search Console flags INP > 200ms on mobile for a majority of pages. The code audit traced this to main-thread contention: GTM loading much earlier than intended, an unthrottled scroll listener shipped on every page, and unnecessary client bundle weight. This PR implements the INP fixes from that audit (LCP fixes are in #82).

## Changes

### 1. GTM is now genuinely deferred
The layout comment claimed GTM was loaded "with lazyOnload strategy", but the `GoogleTagManager` component from `@next/third-parties` accepts no strategy prop — it always injects `afterInteractive`, putting the ~1.9MB GTM container (Clarity, LinkedIn Ads, etc.) on the main thread during the critical window of every page load. Replaced with the standard GTM snippet inside `<Script strategy="lazyOnload">`, so it waits for `window.load`. This is the single largest INP/LCP lever found in the audit.

Verified in rendered HTML: the eager `gtm.js` preload link and inline bootstrapper are gone from the initial payload; the snippet only executes after load.

### 2. New `types/global.d.ts` for third-party window globals
Removing the `@next/third-parties` import surfaced a hidden dependency: its types declare a `[key: string]: any` index signature on `Window`, which is what let `window.hbspt`, `window._hsq`, and `window.GartnerPI_Widget` compile across the HubSpot form components, the tracker, and the G2 widget. Those globals are now declared explicitly.

### 3. Passive, change-guarded header scroll listener
`SiteHeader` (ships on every page) registered a non-passive scroll listener that called `setState` on every scroll event just to toggle a shadow. Now `{ passive: true }` and only sets state when the boolean actually flips. Also syncs with a restored scroll position on mount.

### 4. Per-method lodash imports in client components
`import { entries } from "lodash"` (and friends) pulls the full ~70KB CJS lodash into client chunks since it isn't tree-shakeable. Switched to `lodash/entries`, `lodash/set`, `lodash/shuffle` in `PricingPackagesModule.client`, `G2CrowdReviewListing.client`, and `SingleTestimonialPanel`.

### 5. SplitHero heading cycler pauses when not visible
The homepage hero's word-cycling `setInterval` (3s, with nested timeouts/rAF per tick) ran forever, even in hidden tabs. It now pauses on `visibilitychange` and doesn't start at all under `prefers-reduced-motion`.

### 6. Explicit `optimizePackageImports`
Added `@tabler/icons-react` and `@headlessui/react` to `experimental.optimizePackageImports` — they're on Next 14.2's implicit default list, but making it explicit guarantees per-icon tree-shaking across upgrades.

## Verification

- Dev server against live CMS: homepage, `/product/pricing`, `/blog` all render (200); initial HTML contains no eager GTM script or preload.
- `tsc --noEmit` clean apart from one pre-existing `EventDetails.tsx` error that also fails on pristine `main` (local `node_modules` drift to `@agility/nextjs` 14.0.3 vs the locked 14.0.1 — CI installs from the lockfile and is unaffected).