### PR TITLE
Native Get A Demo form (ad-blocker / incognito resilient, HubSpot-driven)

### DIFF
--- a/app/api/forms/hubspot/route.ts
+++ b/app/api/forms/hubspot/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server"
+
+/**
+ * First-party proxy for HubSpot form submissions.
+ *
+ * The browser POSTs to this same-origin route instead of calling
+ * `api.hsforms.com` directly, so submissions keep working for visitors with
+ * ad blockers / tracking prevention (Edge InPrivate, etc.) that block the
+ * HubSpot domain. We forward server-side to the HubSpot Forms Submission API,
+ * attaching the real client IP for HubSpot analytics/geo.
+ *
+ * See GitHub issue #85.
+ */
+
+// Only our own portal is allowed through, so this can't be abused as an open
+// relay to arbitrary HubSpot portals.
+const ALLOWED_PORTAL_ID = "23239214"
+
+interface SubmitBody {
+	portalId: string
+	formId: string
+	fields: Record<string, string>
+	/** One entry per HubSpot communication-consent checkbox on the form. */
+	communications?: { subscriptionTypeId: number; value: boolean; text?: string }[]
+	/** Defaults to true (implicit processing consent). */
+	consentToProcess?: boolean
+	processingConsentText?: string
+	hutk?: string
+	pageUri?: string
+	pageName?: string
+}
+
+const getClientIp = (req: NextRequest): string | undefined => {
+	const xff = req.headers.get("x-forwarded-for")
+	if (xff) return xff.split(",")[0].trim()
+	return (
+		req.headers.get("x-nf-client-connection-ip") ||
+		req.headers.get("x-real-ip") ||
+		undefined
+	)
+}
+
+export async function POST(req: NextRequest) {
+	let body: SubmitBody
+	try {
+		body = await req.json()
+	} catch {
+		return NextResponse.json({ success: false, message: "Invalid request." }, { status: 400 })
+	}
+
+	const { portalId, formId, fields } = body
+
+	if (portalId !== ALLOWED_PORTAL_ID || !formId) {
+		return NextResponse.json({ success: false, message: "Unknown form." }, { status: 400 })
+	}
+
+	// Honeypot: a real user never fills this hidden field. If it's populated,
+	// silently accept and drop (don't tip off the bot).
+	if (fields?.["_hp_email"]) {
+		return NextResponse.json({ success: true })
+	}
+
+	const hsFields = Object.entries(fields || {})
+		.filter(([name, value]) => name !== "_hp_email" && value != null && `${value}`.trim() !== "")
+		.map(([name, value]) => ({ objectTypeId: "0-1", name, value: `${value}` }))
+
+	const communications = (body.communications || [])
+		.filter((c) => c && c.subscriptionTypeId != null)
+		.map((c) => ({
+			value: !!c.value,
+			subscriptionTypeId: c.subscriptionTypeId,
+			text: c.text || "",
+		}))
+
+	const ipAddress = getClientIp(req)
+
+	const payload = {
+		fields: hsFields,
+		context: {
+			...(body.hutk ? { hutk: body.hutk } : {}),
+			...(ipAddress ? { ipAddress } : {}),
+			pageUri: body.pageUri || "",
+			pageName: body.pageName || "",
+		},
+		legalConsentOptions: {
+			consent: {
+				consentToProcess: body.consentToProcess !== false,
+				text:
+					body.processingConsentText ||
+					"I agree to allow Agility Inc. to store and process my personal data.",
+				...(communications.length ? { communications } : {}),
+			},
+		},
+	}
+
+	try {
+		const hsRes = await fetch(
+			`https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(payload),
+			}
+		)
+
+		if (hsRes.ok) {
+			return NextResponse.json({ success: true })
+		}
+
+		const errBody = await hsRes.json().catch(() => null)
+		const blockedEmail = errBody?.errors?.some(
+			(e: { errorType?: string }) => e.errorType === "BLOCKED_EMAIL"
+		)
+		if (blockedEmail) {
+			// 200 so the client treats it as a handled validation error, not a network failure.
+			return NextResponse.json({ success: false, blockedEmail: true })
+		}
+
+		console.error("HubSpot submission error:", errBody)
+		return NextResponse.json({ success: false, message: "Submission failed." }, { status: 502 })
+	} catch (e) {
+		console.error("HubSpot submission proxy error:", e)
+		return NextResponse.json({ success: false, message: "Submission failed." }, { status: 502 })
+	}
+}

--- a/components/agility-components/GetADemo/GetADemo.client.tsx
+++ b/components/agility-components/GetADemo/GetADemo.client.tsx
@@ -225,7 +225,21 @@ export const GetADemoClient = ({ hubspotForm, redirectURL, formDefinition }: Pro
 
 			const target = redirectURL || def.redirectUrl
 			if (target) {
-				router.push(target)
+				// The redirect is a fully-qualified URL. If it's same-origin, push a
+				// relative path so router.push does a soft (client-side) navigation —
+				// that keeps the JS context alive so the PostHog conversion event above
+				// reliably flushes. A fully-qualified same-origin URL would otherwise be
+				// one protocol/subdomain difference away from a hard page unload.
+				try {
+					const url = new URL(target, window.location.origin)
+					if (url.origin === window.location.origin) {
+						router.push(`${url.pathname}${url.search}${url.hash}`)
+					} else {
+						window.location.href = target
+					}
+				} catch {
+					router.push(target)
+				}
 			} else {
 				setSubmitting(false)
 			}

--- a/components/agility-components/GetADemo/GetADemo.client.tsx
+++ b/components/agility-components/GetADemo/GetADemo.client.tsx
@@ -1,99 +1,353 @@
 "use client"
 
-import Script from "next/script"
+import classNames from "classnames"
 import { capture, identify } from "lib/analytics/posthog"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { LinkButton } from "components/micro/LinkButton"
+import { useCallback, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
+import type {
+	HubSpotFormDefinition,
+	HubSpotFormField,
+} from "lib/hubspot/getHubSpotFormDefinition"
 
 interface Props {
 	hubspotForm?: string
 	redirectURL?: string
+	/** Fetched server-side in GetADemo.tsx. Null -> use FALLBACK_DEFINITION. */
+	formDefinition?: HubSpotFormDefinition | null
 }
 
-const FormBlockedFallback = () => (
-	<div className="min-h-[400px]">
-		<p className="text-sm text-gray-600">
-			Form not loading?{" "}
-			<a
-				href="https://agilitycms.com/thank-you/get-a-demo-step-2-book"
-				target="_blank"
-				rel="noopener noreferrer"
-				className="text-highlight underline hover:text-highlight-dark"
-			>
-				Find the calendar here
-			</a>{" "}
-			to book a demo or reach out to us at{" "}
-			<a href="mailto:sales@agilitycms.com" className="text-highlight underline hover:text-highlight-dark">
-				sales@agilitycms.com
-			</a>
-			.
-		</p>
-	</div>
-)
+const SUBMIT_ENDPOINT = "/api/forms/hubspot"
 
-export const GetADemoClient = ({ hubspotForm, redirectURL }: Props) => {
-	const { portalId, formId, name } = JSON.parse(hubspotForm || '{"portalId": "", "formId": ""}')
-	const divID = `get-a-demo-form-${formId}`
-	const formLoadRef = useRef<boolean>(false)
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+// Used ONLY if the server-side definition fetch failed, so the form always
+// renders. Mirrors the live "Demo Request On All Agility.com Webpages" form.
+const FALLBACK_DEFINITION: HubSpotFormDefinition = {
+	submitText: "Let's chat",
+	redirectUrl: "",
+	fields: [
+		{ name: "firstname", label: "First name", fieldType: "text", required: true, hidden: false, placeholder: "", defaultValue: "", objectTypeId: "0-1", blockFreeEmail: false, options: [] },
+		{ name: "lastname", label: "Last name", fieldType: "text", required: true, hidden: false, placeholder: "", defaultValue: "", objectTypeId: "0-1", blockFreeEmail: false, options: [] },
+		{ name: "company", label: "Company name", fieldType: "text", required: true, hidden: false, placeholder: "", defaultValue: "", objectTypeId: "0-1", blockFreeEmail: false, options: [] },
+		{ name: "email", label: "Business Email", fieldType: "text", required: true, hidden: false, placeholder: "", defaultValue: "", objectTypeId: "0-1", blockFreeEmail: true, options: [] },
+	],
+	processingConsentText: "I agree to allow Agility Inc. to store and process my personal data.",
+	processingConsentType: "IMPLICIT",
+	isLegitimateInterest: false,
+	communicationConsentCheckboxes: [
+		{ communicationTypeId: 61656565, label: "I would like to receive marketing communications from Agility CMS on product & industry updates, services and events. I understand I can unsubscribe at any time.", required: false },
+	],
+	captchaEnabled: false,
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+// Common free / personal email providers. Mirrors HubSpot's "block free email
+// domains" validation for instant client-side feedback; HubSpot's server-side
+// list stays the authoritative backstop (BLOCKED_EMAIL) for anything not here.
+const FREE_EMAIL_DOMAINS = new Set([
+	"gmail.com", "googlemail.com",
+	"yahoo.com", "yahoo.co.uk", "yahoo.co.in", "yahoo.ca", "yahoo.fr", "ymail.com", "rocketmail.com",
+	"hotmail.com", "hotmail.co.uk", "hotmail.fr", "outlook.com", "outlook.co.uk", "live.com", "msn.com",
+	"aol.com", "icloud.com", "me.com", "mac.com",
+	"protonmail.com", "proton.me", "pm.me", "gmx.com", "gmx.net", "mail.com", "hey.com", "fastmail.com",
+	"yandex.com", "yandex.ru", "zoho.com",
+	"qq.com", "163.com", "126.com", "sina.com", "naver.com",
+	"comcast.net", "verizon.net", "att.net", "sbcglobal.net", "bellsouth.net", "cox.net",
+	"rediffmail.com", "hushmail.com", "inbox.com",
+])
+
+const isFreeEmailDomain = (email: string): boolean => {
+	const at = email.lastIndexOf("@")
+	if (at === -1) return false
+	return FREE_EMAIL_DOMAINS.has(email.slice(at + 1).trim().toLowerCase())
+}
+
+// autoComplete hints keyed by HubSpot field name.
+const AUTOCOMPLETE: Record<string, string> = {
+	firstname: "given-name",
+	lastname: "family-name",
+	company: "organization",
+	email: "email",
+	phone: "tel",
+	mobilephone: "tel",
+	jobtitle: "organization-title",
+}
+
+const isEmailField = (f: HubSpotFormField): boolean =>
+	f.name === "email" || f.fieldType === "email"
+
+const inputTypeFor = (f: HubSpotFormField): string => {
+	if (isEmailField(f)) return "email"
+	if (f.fieldType === "phonenumber" || f.name.includes("phone")) return "tel"
+	if (f.fieldType === "number") return "number"
+	return "text"
+}
+
+const getCookie = (key: string): string | undefined => {
+	if (typeof document === "undefined") return undefined
+	const value = `; ${document.cookie}`
+	const parts = value.split(`; ${key}=`)
+	if (parts.length === 2) return parts.pop()?.split(";").shift()
+	return undefined
+}
+
+const SUBMIT_ERROR_MESSAGE =
+	"Something went wrong submitting the form. Please try again or email sales@agilitycms.com."
+
+export const GetADemoClient = ({ hubspotForm, redirectURL, formDefinition }: Props) => {
+	const def = formDefinition ?? FALLBACK_DEFINITION
+	const { portalId, formId, name: formName } = JSON.parse(
+		hubspotForm || '{"portalId":"","formId":"","name":""}'
+	)
 	const router = useRouter()
-	const [formBlocked, setFormBlocked] = useState(false)
 
-	const loadForm = useCallback(() => {
-		if (formLoadRef.current) return
-		if (!window.hbspt) return
-		formLoadRef.current = true
+	const visibleFields = useMemo(() => def.fields.filter((f) => !f.hidden), [def])
+	const hiddenFields = useMemo(() => def.fields.filter((f) => f.hidden), [def])
 
-		window.hbspt.forms.create({
-			portalId,
-			formId,
-			target: `#${divID}`,
-			onFormReady: () => {
-				if (timeoutRef.current) clearTimeout(timeoutRef.current)
-			},
-			onFormSubmitted: function (_: any, data: any) {
-				console.log("Form submitted successfully:", name)
-				const emailAddress = data?.submissionValues?.email
-				if (emailAddress) {
-					identify(emailAddress)
-				}
+	const [values, setValues] = useState<Record<string, string>>(() =>
+		Object.fromEntries(def.fields.map((f) => [f.name, f.defaultValue || ""]))
+	)
+	const [consents, setConsents] = useState<Record<number, boolean>>(() =>
+		Object.fromEntries(def.communicationConsentCheckboxes.map((c) => [c.communicationTypeId, false]))
+	)
+	const [errors, setErrors] = useState<Record<string, string | undefined>>({})
+	const [submitting, setSubmitting] = useState(false)
+	const [submitError, setSubmitError] = useState<string | null>(null)
+	const honeypotRef = useRef<HTMLInputElement>(null)
 
-				capture("website-form-submission", {
-					name: name
-				})
+	const setField = (name: string, value: string) => {
+		setValues((v) => ({ ...v, [name]: value }))
+		if (errors[name]) setErrors((e) => ({ ...e, [name]: undefined }))
+	}
 
-				if (redirectURL) {
-					router.push(redirectURL)
-				}
-			}
-		})
-
-		// Show fallback only if HubSpot hasn't rendered after 8s — long enough
-		// for slow connections to succeed without racing a still-loading form.
-		// onFormReady cancels this if the form renders successfully.
-		timeoutRef.current = setTimeout(() => {
-			const el = document.getElementById(divID)
-			if (el && el.children.length === 0) {
-				setFormBlocked(true)
-			}
-		}, 8000)
-	}, [divID, formId, portalId, name, redirectURL, router])
-
-	useEffect(() => {
-		if (window.hbspt) {
-			loadForm()
+	// Per-field validation. Returns an error message or undefined.
+	const getFieldError = useCallback((f: HubSpotFormField, raw: string): string | undefined => {
+		const val = (raw ?? "").trim()
+		if (f.required && !val) return `${f.label || f.name} is required.`
+		if (isEmailField(f) && val) {
+			if (!EMAIL_RE.test(val)) return "Please enter a valid email address."
+			if (f.blockFreeEmail && isFreeEmailDomain(val)) return "Please use your business email address."
 		}
-	}, [loadForm])
+		return undefined
+	}, [])
+
+	const validate = useCallback((): boolean => {
+		const next: Record<string, string | undefined> = {}
+		let ok = true
+		for (const f of visibleFields) {
+			const err = getFieldError(f, values[f.name] || "")
+			if (err) {
+				next[f.name] = err
+				ok = false
+			}
+		}
+		for (const c of def.communicationConsentCheckboxes) {
+			if (c.required && !consents[c.communicationTypeId]) {
+				next[`consent_${c.communicationTypeId}`] = "This consent is required."
+				ok = false
+			}
+		}
+		setErrors(next)
+		return ok
+	}, [visibleFields, values, def.communicationConsentCheckboxes, consents, getFieldError])
+
+	// Instant feedback on blur for the work-email field only (skip when empty).
+	const handleFieldBlur = (f: HubSpotFormField) => {
+		if (!isEmailField(f)) return
+		if (!(values[f.name] || "").trim()) return
+		setErrors((prev) => ({ ...prev, [f.name]: getFieldError(f, values[f.name] || "") }))
+	}
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault()
+		setSubmitError(null)
+		if (submitting) return
+		if (!validate()) return
+
+		setSubmitting(true)
+
+		// Hidden fields (e.g. utm_*) are populated from matching URL query params,
+		// falling back to the field's default — matching HubSpot's embed behavior.
+		const sp = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams()
+		const fieldsPayload: Record<string, string> = {}
+		for (const f of visibleFields) fieldsPayload[f.name] = (values[f.name] || "").trim()
+		for (const f of hiddenFields) {
+			const v = sp.get(f.name) ?? f.defaultValue ?? ""
+			if (v) fieldsPayload[f.name] = v
+		}
+		fieldsPayload._hp_email = honeypotRef.current?.value || ""
+
+		const communications = def.communicationConsentCheckboxes.map((c) => ({
+			subscriptionTypeId: c.communicationTypeId,
+			value: !!consents[c.communicationTypeId],
+			text: c.label,
+		}))
+
+		try {
+			const res = await fetch(SUBMIT_ENDPOINT, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					portalId: `${portalId}`,
+					formId,
+					fields: fieldsPayload,
+					communications,
+					processingConsentText: def.processingConsentText,
+					hutk: getCookie("hubspotutk"),
+					pageUri: typeof window !== "undefined" ? window.location.href : "",
+					pageName: typeof document !== "undefined" ? document.title : "",
+				}),
+			})
+
+			const data = await res.json().catch(() => null)
+
+			// HubSpot's server-side "block free email domains" backstop.
+			if (data?.blockedEmail) {
+				const emailField = visibleFields.find(isEmailField)
+				if (emailField) {
+					setErrors((prev) => ({ ...prev, [emailField.name]: "Please use your business email address." }))
+				}
+				setSubmitting(false)
+				return
+			}
+
+			if (!res.ok || !data?.success) {
+				setSubmitError(SUBMIT_ERROR_MESSAGE)
+				setSubmitting(false)
+				return
+			}
+
+			// --- Conversion tracking: parity with the old embed's onFormSubmitted ---
+			const emailField = visibleFields.find(isEmailField)
+			const email = emailField ? (values[emailField.name] || "").trim() : ""
+			if (email) identify(email)
+			capture("website-form-submission", { name: formName })
+
+			const target = redirectURL || def.redirectUrl
+			if (target) {
+				router.push(target)
+			} else {
+				setSubmitting(false)
+			}
+		} catch (err) {
+			console.error("Demo form submission error:", err)
+			setSubmitError(SUBMIT_ERROR_MESSAGE)
+			setSubmitting(false)
+		}
+	}
+
+	const inputClass = (hasError: boolean) =>
+		classNames(
+			"w-full rounded-md border px-3 py-2 text-gray-900 shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-highlight-light disabled:bg-gray-50",
+			hasError ? "border-red-400" : "border-gray-300"
+		)
 
 	return (
-		<>
-			<Script
-				src="https://js.hsforms.net/forms/v2.js"
-				async
-				onLoad={() => loadForm()}
-				onError={() => setFormBlocked(true)}
-			/>
-			{formBlocked ? <FormBlockedFallback /> : <div id={divID} className="min-h-[400px]"></div>}
-		</>
+		<form onSubmit={handleSubmit} noValidate className="space-y-4">
+			{visibleFields.map((f) => {
+				const id = `demo-${f.name}`
+				const err = errors[f.name]
+				const common = {
+					id,
+					name: f.name,
+					value: values[f.name] || "",
+					"aria-invalid": !!err,
+					"aria-describedby": err ? `${id}-error` : undefined,
+					disabled: submitting,
+					required: f.required,
+					placeholder: f.placeholder || undefined,
+				}
+				return (
+					<div key={f.name}>
+						{f.label && (
+							<label htmlFor={id} className="mb-1 block text-sm font-medium text-gray-700">
+								{f.label} {f.required && <span className="text-red-500">*</span>}
+							</label>
+						)}
+						{f.fieldType === "textarea" ? (
+							<textarea
+								{...common}
+								rows={4}
+								onChange={(e) => setField(f.name, e.target.value)}
+								className={inputClass(!!err)}
+							/>
+						) : f.fieldType === "select" ? (
+							<select
+								{...common}
+								onChange={(e) => setField(f.name, e.target.value)}
+								className={inputClass(!!err)}
+							>
+								<option value="">{f.placeholder || "Please select"}</option>
+								{f.options.map((o) => (
+									<option key={o.value} value={o.value}>
+										{o.label}
+									</option>
+								))}
+							</select>
+						) : (
+							<input
+								{...common}
+								type={inputTypeFor(f)}
+								autoComplete={AUTOCOMPLETE[f.name]}
+								onChange={(e) => setField(f.name, e.target.value)}
+								onBlur={() => handleFieldBlur(f)}
+								className={inputClass(!!err)}
+							/>
+						)}
+						{err && (
+							<p id={`${id}-error`} className="mt-1 text-sm text-red-600">
+								{err}
+							</p>
+						)}
+					</div>
+				)
+			})}
+
+			{/* Honeypot — hidden from users, catches bots (form has no captcha). */}
+			<div aria-hidden="true" className="absolute left-[-9999px] h-0 w-0 overflow-hidden">
+				<label>
+					Please leave this field empty
+					<input ref={honeypotRef} type="text" name="_hp_email" tabIndex={-1} autoComplete="off" />
+				</label>
+			</div>
+
+			{def.communicationConsentCheckboxes.map((c) => {
+				const cid = `demo-consent-${c.communicationTypeId}`
+				const err = errors[`consent_${c.communicationTypeId}`]
+				return (
+					<div key={c.communicationTypeId}>
+						<div className="flex items-start gap-2">
+							<input
+								id={cid}
+								type="checkbox"
+								checked={!!consents[c.communicationTypeId]}
+								onChange={(e) =>
+									setConsents((prev) => ({ ...prev, [c.communicationTypeId]: e.target.checked }))
+								}
+								disabled={submitting}
+								className="mt-1 h-4 w-4 rounded border-gray-300 text-highlight-light focus:ring-highlight-light"
+							/>
+							<label htmlFor={cid} className="text-xs text-gray-600">
+								{c.label} {c.required && <span className="text-red-500">*</span>}
+							</label>
+						</div>
+						{err && <p className="mt-1 text-sm text-red-600">{err}</p>}
+					</div>
+				)
+			})}
+
+			{/* Processing consent is IMPLICIT — not displayed (matches the HubSpot form),
+			    but still sent in the submission payload for the legal-basis record. */}
+
+			{submitError && (
+				<p role="alert" className="text-sm text-red-600">
+					{submitError}
+				</p>
+			)}
+
+			<LinkButton type="primary" size="lg" buttonType="submit" disabled={submitting} className="w-full">
+				{submitting ? "Submitting…" : def.submitText}
+			</LinkButton>
+		</form>
 	)
 }

--- a/components/agility-components/GetADemo/GetADemo.tsx
+++ b/components/agility-components/GetADemo/GetADemo.tsx
@@ -4,6 +4,7 @@ import { Container } from "components/micro/Container"
 import { renderHTMLCustom } from "lib/utils/renderHtmlCustom"
 import { GetADemoClient } from "./GetADemo.client"
 import { VimeoVideoPlayer, VimeoVideoData } from "components/common/VimeoVideoPlayer"
+import { getHubSpotFormDefinition } from "lib/hubspot/getHubSpotFormDefinition"
 
 export interface IGetADemo {
 	heading?: string
@@ -19,14 +20,28 @@ export interface IGetADemo {
 }
 
 export const GetADemo = async ({ module, languageCode }: UnloadedModuleProps) => {
-	const { fields, contentID } = await getContentItem<IGetADemo>({
+	const contentItem = await getContentItem<IGetADemo>({
 		contentID: module.contentid,
 		languageCode,
 	})
 
+	const { fields, contentID } = contentItem
+
 	if (!fields.hubspotForm) {
 		console.warn(`GetADemo module with contentID ${contentID} is missing a HubSpot form`)
 		return null
+	}
+
+	// Fetch the HubSpot form definition SERVER-SIDE (server -> HubSpot) so the
+	// browser never requests forms.hsforms.com — ad blockers / InPrivate can't
+	// block it. The client renders natively from this; a null result falls back
+	// to the component's hardcoded defaults so the form always renders.
+	let hubspotFormDefinition = null
+	try {
+		const { portalId, formId } = JSON.parse(fields.hubspotForm)
+		hubspotFormDefinition = await getHubSpotFormDefinition(portalId, formId)
+	} catch (error) {
+		console.error("GetADemo: failed to parse hubspotForm field:", error)
 	}
 
 	// Parse Vimeo video data if present
@@ -91,6 +106,7 @@ export const GetADemo = async ({ module, languageCode }: UnloadedModuleProps) =>
 								<GetADemoClient
 									hubspotForm={fields.hubspotForm}
 									redirectURL={fields.redirectURL}
+									formDefinition={hubspotFormDefinition}
 								/>
 							</div>
 							{fields.formBottomImage?.url && (

--- a/components/common/header/MenuItemOutput.tsx
+++ b/components/common/header/MenuItemOutput.tsx
@@ -39,7 +39,6 @@ export const MenuItemOutput = ({ link }: Props) => {
 	}
 
 	const cancelShowSubmenu = () => {
-		console.log("cancelShowSubmenu")
 		clearTimeout(refShowSubmenuDelay.current)
 		refIsMouseOnPopover.current = false
 	}
@@ -152,21 +151,21 @@ export const MenuItemOutput = ({ link }: Props) => {
 							<div className="flex flex-1 gap-1">
 								<div className="relative grid min-w-[260px] gap-5  px-6 py-7">
 									{link.subMenuList
-									?.filter((subLink) => subLink.fields.uRL?.href)
-									.map((subLink) => (
-										<Link
-											key={subLink.contentID}
-											href={subLink.fields.uRL!.href}
-											target={subLink.fields.uRL!.target}
-											className={classNames(
-												"text-secondary-500 text-sm font-medium leading-6",
-												"transition-all duration-300 hover:text-highlight focus:text-highlight focus:outline-none"
-											)}
-											onClick={() => close()}
-										>
-											{subLink.fields.uRL!.text || subLink.fields.title}
-										</Link>
-									))}
+										?.filter((subLink) => subLink.fields.uRL?.href)
+										.map((subLink) => (
+											<Link
+												key={subLink.contentID}
+												href={subLink.fields.uRL!.href}
+												target={subLink.fields.uRL!.target}
+												className={classNames(
+													"text-secondary-500 text-sm font-medium leading-6",
+													"transition-all duration-300 hover:text-highlight focus:text-highlight focus:outline-none"
+												)}
+												onClick={() => close()}
+											>
+												{subLink.fields.uRL!.text || subLink.fields.title}
+											</Link>
+										))}
 								</div>
 								{megaContent && megaTitle && (
 									<div className="flex-1 bg-gray-100 px-6 py-7">

--- a/lib/hubspot/getHubSpotFormDefinition.ts
+++ b/lib/hubspot/getHubSpotFormDefinition.ts
@@ -1,0 +1,141 @@
+/**
+ * Fetches a HubSpot form's definition SERVER-SIDE from the public embed JSON
+ * endpoint and normalizes it into a shape our native forms can render.
+ *
+ * Because this runs in a Server Component (server -> HubSpot), the browser
+ * never requests `forms.hsforms.com`, so ad blockers / InPrivate can't block
+ * it. The parsed result ships to the client inside our own page payload.
+ *
+ * Callers should treat a `null` return as "use hardcoded fallbacks" so the
+ * form still renders if HubSpot is unreachable. See GitHub issue #85.
+ */
+
+export interface HubSpotFormField {
+	name: string
+	label: string
+	/** HubSpot fieldType: "text" | "textarea" | "select" | "phonenumber" | ... */
+	fieldType: string
+	required: boolean
+	hidden: boolean
+	placeholder: string
+	defaultValue: string
+	/** HubSpot object type, almost always "0-1" (Contact). */
+	objectTypeId: string
+	/** email field with "block free/personal email domains" enabled. */
+	blockFreeEmail: boolean
+	options: { label: string; value: string }[]
+}
+
+export interface HubSpotConsentCheckbox {
+	/** Maps to `subscriptionTypeId` in the Forms submission API. */
+	communicationTypeId: number
+	label: string
+	required: boolean
+}
+
+export interface HubSpotFormDefinition {
+	submitText: string
+	redirectUrl: string
+	fields: HubSpotFormField[]
+	/** Processing-consent copy (shown as text when type is IMPLICIT). */
+	processingConsentText: string
+	processingConsentType: string
+	isLegitimateInterest: boolean
+	communicationConsentCheckboxes: HubSpotConsentCheckbox[]
+	captchaEnabled: boolean
+}
+
+// HubSpot returns consent labels with HTML entities (e.g. "&amp;").
+const decodeEntities = (s: string): string =>
+	s
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&nbsp;/g, " ")
+
+// Cache the definition for 30 min so marketer edits in HubSpot propagate
+// without a redeploy, while keeping the server->HubSpot call off the hot path.
+const REVALIDATE_SECONDS = 1800
+
+export async function getHubSpotFormDefinition(
+	portalId: string | number,
+	formId: string
+): Promise<HubSpotFormDefinition | null> {
+	if (!portalId || !formId) return null
+
+	try {
+		const url = `https://forms.hsforms.com/embed/v3/form/${portalId}/${formId}/json`
+		const res = await fetch(url, { next: { revalidate: REVALIDATE_SECONDS } })
+		if (!res.ok) {
+			console.warn(`HubSpot form definition fetch failed (${res.status}) for form ${formId}`)
+			return null
+		}
+
+		const json = await res.json()
+		const form = json?.form
+		if (!form) return null
+
+		const fields: HubSpotFormField[] = []
+		for (const group of form.formFieldGroups || []) {
+			for (const fl of group.fields || []) {
+				fields.push({
+					name: fl.name,
+					label: fl.label ?? "",
+					fieldType: fl.fieldType ?? "text",
+					required: !!fl.required,
+					hidden: !!fl.hidden,
+					placeholder: fl.placeholder ?? "",
+					defaultValue: fl.defaultValue ?? "",
+					objectTypeId: fl.objectTypeId ?? "0-1",
+					blockFreeEmail: !!fl.validation?.useDefaultBlockList,
+					options: (fl.options || []).map((o: { label: string; value: string }) => ({
+						label: o.label,
+						value: o.value,
+					})),
+				})
+			}
+		}
+
+		let processingConsentText = ""
+		let processingConsentType = ""
+		let isLegitimateInterest = false
+		let communicationConsentCheckboxes: HubSpotConsentCheckbox[] = []
+
+		const lcoRaw = (form.metaData || []).find(
+			(m: { name: string; value: string }) => m.name === "legalConsentOptions"
+		)?.value
+		if (lcoRaw) {
+			try {
+				const lco = JSON.parse(lcoRaw)
+				processingConsentText = decodeEntities(lco.processingConsentCheckboxLabel ?? "")
+				processingConsentType = lco.processingConsentType ?? ""
+				isLegitimateInterest = !!lco.isLegitimateInterest
+				communicationConsentCheckboxes = (lco.communicationConsentCheckboxes || []).map(
+					(c: { communicationTypeId: number; label: string; required: boolean }) => ({
+						communicationTypeId: c.communicationTypeId,
+						label: decodeEntities(c.label ?? ""),
+						required: !!c.required,
+					})
+				)
+			} catch (e) {
+				console.warn("Failed to parse HubSpot legalConsentOptions:", e)
+			}
+		}
+
+		return {
+			submitText: form.submitText || "Submit",
+			redirectUrl: form.redirectUrl || "",
+			fields,
+			processingConsentText,
+			processingConsentType,
+			isLegitimateInterest,
+			communicationConsentCheckboxes,
+			captchaEnabled: !!form.captchaEnabled,
+		}
+	} catch (e) {
+		console.error("Failed to fetch HubSpot form definition:", e)
+		return null
+	}
+}

--- a/styles/output.css
+++ b/styles/output.css
@@ -12,6 +12,7 @@
     --color-red-200: oklch(88.5% 0.062 18.334);
     --color-red-400: oklch(70.4% 0.191 22.216);
     --color-red-500: oklch(63.7% 0.237 25.331);
+    --color-red-600: oklch(57.7% 0.245 27.325);
     --color-red-800: oklch(44.4% 0.177 26.899);
     --color-orange-500: oklch(70.5% 0.213 47.604);
     --color-amber-50: oklch(98.7% 0.022 95.277);
@@ -327,9 +328,6 @@
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
   }
-  .-top-1 {
-    top: calc(var(--spacing) * -1);
-  }
   .-top-1\/2 {
     top: calc(calc(1/2 * 100%) * -1);
   }
@@ -354,9 +352,6 @@
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
-  .top-1 {
-    top: calc(var(--spacing) * 1);
-  }
   .top-1\/2 {
     top: calc(1/2 * 100%);
   }
@@ -375,9 +370,6 @@
   .top-\[83px\] {
     top: 83px;
   }
-  .-right-1 {
-    right: calc(var(--spacing) * -1);
-  }
   .-right-1\/4 {
     right: calc(calc(1/4 * 100%) * -1);
   }
@@ -395,9 +387,6 @@
   }
   .right-0 {
     right: calc(var(--spacing) * 0);
-  }
-  .right-1 {
-    right: calc(var(--spacing) * 1);
   }
   .right-1\/2 {
     right: calc(1/2 * 100%);
@@ -456,9 +445,6 @@
   .left-0 {
     left: calc(var(--spacing) * 0);
   }
-  .left-1 {
-    left: calc(var(--spacing) * 1);
-  }
   .left-1\/2 {
     left: calc(1/2 * 100%);
   }
@@ -476,6 +462,9 @@
   }
   .left-10 {
     left: calc(var(--spacing) * 10);
+  }
+  .left-\[-9999px\] {
+    left: -9999px;
   }
   .isolate {
     isolation: isolate;
@@ -537,14 +526,8 @@
       max-width: 96rem;
     }
   }
-  .-m-1 {
-    margin: calc(var(--spacing) * -1);
-  }
   .-m-1\.5 {
     margin: calc(var(--spacing) * -1.5);
-  }
-  .-m-2 {
-    margin: calc(var(--spacing) * -2);
   }
   .-m-2\.5 {
     margin: calc(var(--spacing) * -2.5);
@@ -1636,9 +1619,6 @@
   .-mt-44 {
     margin-top: calc(var(--spacing) * -44);
   }
-  .mt-0 {
-    margin-top: calc(var(--spacing) * 0);
-  }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
   }
@@ -2228,16 +2208,8 @@
   .origin-top {
     transform-origin: top;
   }
-  .-translate-x-1 {
-    --tw-translate-x: calc(var(--spacing) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
   .-translate-x-1\/2 {
     --tw-translate-x: calc(calc(1/2 * 100%) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-  .-translate-y-1 {
-    --tw-translate-y: calc(var(--spacing) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
@@ -2461,11 +2433,6 @@
       border-top-style: var(--tw-border-style);
       border-top-width: calc(1px * var(--tw-divide-y-reverse));
       border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
-    }
-  }
-  .divide-gray-500 {
-    :where(& > :not(:last-child)) {
-      border-color: var(--color-gray-500);
     }
   }
   .divide-gray-500\/10 {
@@ -2705,9 +2672,6 @@
   .border-t-white {
     border-top-color: var(--color-white);
   }
-  .border-r-white {
-    border-right-color: var(--color-white);
-  }
   .border-r-white\/20 {
     border-right-color: color-mix(in srgb, #fff 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2828,9 +2792,6 @@
   .bg-gray-300 {
     background-color: var(--color-gray-300);
   }
-  .bg-gray-500 {
-    background-color: var(--color-gray-500);
-  }
   .bg-gray-500\/75 {
     background-color: color-mix(in srgb, oklch(55.1% 0.027 264.364) 75%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2896,9 +2857,6 @@
   }
   .bg-purple-50 {
     background-color: var(--color-purple-50);
-  }
-  .bg-purple-100 {
-    background-color: var(--color-purple-100);
   }
   .bg-purple-100\/50 {
     background-color: color-mix(in srgb, oklch(94.6% 0.033 307.174) 50%, transparent);
@@ -2999,9 +2957,6 @@
   .bg-zinc-50 {
     background-color: var(--color-zinc-50);
   }
-  .bg-zinc-400 {
-    background-color: var(--color-zinc-400);
-  }
   .bg-zinc-400\/25 {
     background-color: color-mix(in srgb, oklch(70.5% 0.015 286.067) 25%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -3059,10 +3014,6 @@
     }
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
-  .from-gray-100 {
-    --tw-gradient-from: var(--color-gray-100);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
   .from-gray-100\/40 {
     --tw-gradient-from: color-mix(in srgb, oklch(96.7% 0.003 264.542) 40%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -3110,11 +3061,6 @@
     --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
     --tw-gradient-stops: var(--tw-gradient-via-stops);
   }
-  .via-purple-50 {
-    --tw-gradient-via: var(--color-purple-50);
-    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
-    --tw-gradient-stops: var(--tw-gradient-via-stops);
-  }
   .via-purple-50\/40 {
     --tw-gradient-via: color-mix(in srgb, oklch(97.7% 0.014 308.299) 40%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -3145,19 +3091,11 @@
     --tw-gradient-to: var(--color-highlight-dark);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
-  .to-purple-50 {
-    --tw-gradient-to: var(--color-purple-50);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
   .to-purple-50\/50 {
     --tw-gradient-to: color-mix(in srgb, oklch(97.7% 0.014 308.299) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       --tw-gradient-to: color-mix(in oklab, var(--color-purple-50) 50%, transparent);
     }
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
-  .to-purple-100 {
-    --tw-gradient-to: var(--color-purple-100);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-purple-100\/40 {
@@ -3191,9 +3129,6 @@
   }
   .bg-no-repeat {
     background-repeat: no-repeat;
-  }
-  .stroke-gray-900 {
-    stroke: var(--color-gray-900);
   }
   .stroke-gray-900\/10 {
     stroke: color-mix(in srgb, oklch(21% 0.034 264.665) 10%, transparent);
@@ -3287,9 +3222,6 @@
   }
   .px-10 {
     padding-inline: calc(var(--spacing) * 10);
-  }
-  .py-0 {
-    padding-block: calc(var(--spacing) * 0);
   }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
@@ -3592,9 +3524,6 @@
   .text-nowrap {
     text-wrap: nowrap;
   }
-  .text-wrap {
-    text-wrap: wrap;
-  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -3693,6 +3622,9 @@
   }
   .text-red-500 {
     color: var(--color-red-500);
+  }
+  .text-red-600 {
+    color: var(--color-red-600);
   }
   .text-red-800 {
     color: var(--color-red-800);
@@ -3814,12 +3746,6 @@
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .shadow-purple-600 {
-    --tw-shadow-color: oklch(55.8% 0.288 302.321);
-    @supports (color: color-mix(in lab, red, red)) {
-      --tw-shadow-color: color-mix(in oklab, var(--color-purple-600) var(--tw-shadow-alpha), transparent);
-    }
-  }
   .shadow-purple-600\/10 {
     --tw-shadow-color: color-mix(in srgb, oklch(55.8% 0.288 302.321) 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -3868,18 +3794,11 @@
   .ring-white {
     --tw-ring-color: var(--color-white);
   }
-  .ring-zinc-900 {
-    --tw-ring-color: var(--color-zinc-900);
-  }
   .ring-zinc-900\/7\.5 {
     --tw-ring-color: color-mix(in srgb, oklch(21% 0.006 285.885) 7.5%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       --tw-ring-color: color-mix(in oklab, var(--color-zinc-900) 7.5%, transparent);
     }
-  }
-  .outline {
-    outline-style: var(--tw-outline-style);
-    outline-width: 1px;
   }
   .outline-highlight {
     outline-color: var(--color-highlight);
@@ -3905,10 +3824,6 @@
   }
   .backdrop-blur-sm {
     --tw-backdrop-blur: blur(var(--blur-sm));
-    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-  }
-  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
@@ -4547,6 +4462,11 @@
   .active\:bg-indigo-700 {
     &:active {
       background-color: var(--color-indigo-700);
+    }
+  }
+  .disabled\:bg-gray-50 {
+    &:disabled {
+      background-color: var(--color-gray-50);
     }
   }
   .aria-selected\:bg-zinc-50 {
@@ -7505,11 +7425,6 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
-@property --tw-outline-style {
-  syntax: "*";
-  inherits: false;
-  initial-value: solid;
-}
 @property --tw-blur {
   syntax: "*";
   inherits: false;
@@ -7668,7 +7583,6 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
-      --tw-outline-style: solid;
       --tw-blur: initial;
       --tw-brightness: initial;
       --tw-contrast: initial;


### PR DESCRIPTION
Part of #85.

## Problem
The **Get A Demo** form on `/demo-request` used the HubSpot iframe embed (`js.hsforms.net/forms/v2.js`). Ad blockers block that domain and Edge InPrivate blocks the iframe/cookies, so the form silently failed to render/submit for a meaningful slice of visitors — lost demo requests, not just lost analytics. (We'd previously shipped a "form not loading? here's a calendar link" fallback as a band-aid.)

## Approach
Render the form as **native HTML**, and pull its configuration **live from HubSpot at runtime, server-side**.

### Loads for everyone
- Native `<form>` — no `js.hsforms.net` script, no iframe. Renders regardless of ad blockers / private mode.
- The HubSpot **form definition is fetched server-side** (`server → forms.hsforms.com`) in the `GetADemo` server component, so the browser never touches a blockable HubSpot domain. Cached 30 min via the Next data cache.
- Submissions go through a **first-party proxy** (`app/api/forms/hubspot/route.ts`) → the browser only POSTs to our own domain, so the submit path is ad-blocker resilient too. The route forwards the `hubspotutk` session id + client IP and surfaces HubSpot `BLOCKED_EMAIL` as an inline error.

### Marketer self-service (no redeploy)
Field list, labels, required flags, field order, dropdown options, submit-button text, consent checkbox(es) + subscription type, and redirect URL are all read from the live HubSpot definition. Marketing edits the form in HubSpot and it flows through (~30 min cache).

**Not auto-supported** (need a dev): exotic field types (date/file/radio/checkbox-group/multi-select), conditional/dependent fields, progressive profiling, reCAPTCHA, multi-column layout. Suggested marketer heads-up copy is in the issue.

### Parity kept
- `hubspotutk` session id forwarded (verified it matches HubSpot's `vi=` visitor id)
- Conversion tracking: `identify(email)` + `capture("website-form-submission", { name })`
- Work-email validation: instant client-side pre-check for free/personal domains, with HubSpot's server-side list as the authoritative backstop
- Honeypot spam field (this form has no captcha)
- Processing consent is IMPLICIT → not displayed (matches the HubSpot form) but still sent in the payload for the legal-basis record

### Resilience
If the server-side definition fetch fails, a hardcoded `FALLBACK_DEFINITION` renders the current form so it never breaks.

## Verification (dev server, live CMS + HubSpot)
- ✅ Native form renders; no `js.hsforms.net` / iframe in the DOM
- ✅ Required-field + email-format + free-domain validation (0 network calls when blocked client-side)
- ✅ Full round-trip: submit → first-party proxy → HubSpot → success `{success:true}` → redirect to thank-you page (browser never contacts `api.hsforms.com`)
- ✅ `BLOCKED_EMAIL` from HubSpot surfaces as an inline field error
- ✅ Payload confirmed: `communications[]` (subscriptionTypeId `61656565`), `hutk` present, consent text — all sourced from the runtime definition
- ✅ Server render confirmed reading from HubSpot (processing text = HubSpot's "Agility CMS (Pro)", not the fallback)

## Files
- **new** `lib/hubspot/getHubSpotFormDefinition.ts` — server-side fetch/parse of the HubSpot form definition (cached, null-safe)
- **new** `app/api/forms/hubspot/route.ts` — first-party submission proxy (portal-allowlisted, honeypot, generic `communications[]`)
- `components/agility-components/GetADemo/GetADemo.tsx` — fetches definition server-side, passes to client
- `components/agility-components/GetADemo/GetADemo.client.tsx` — native definition-driven form
- `styles/output.css` — Tailwind regen for the new form utility classes

## Note
`js.hsforms.net` is still loaded by the other form components (GatedDownload, SubmissionForm, DownloadForm, GetPricePopup, Pricing, FooterSubscribe) until they're migrated to this pattern. Once all are native we can also drop the `preconnect` to `js.hsforms.net` in the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
