### PR TITLE
fix: stop demo-form honeypot from dropping real submissions via browser autofill

### DIFF
--- a/app/api/forms/hubspot/route.ts
+++ b/app/api/forms/hubspot/route.ts
@@ -56,12 +56,12 @@ export async function POST(req: NextRequest) {
 
 	// Honeypot: a real user never fills this hidden field. If it's populated,
 	// silently accept and drop (don't tip off the bot).
-	if (fields?.["_hp_email"]) {
+	if (fields?.["_hp_extra_field"]) {
 		return NextResponse.json({ success: true })
 	}
 
 	const hsFields = Object.entries(fields || {})
-		.filter(([name, value]) => name !== "_hp_email" && value != null && `${value}`.trim() !== "")
+		.filter(([name, value]) => name !== "_hp_extra_field" && value != null && `${value}`.trim() !== "")
 		.map(([name, value]) => ({ objectTypeId: "0-1", name, value: `${value}` }))
 
 	const communications = (body.communications || [])

--- a/components/agility-components/GetADemo/GetADemo.client.tsx
+++ b/components/agility-components/GetADemo/GetADemo.client.tsx
@@ -173,7 +173,7 @@ export const GetADemoClient = ({ hubspotForm, redirectURL, formDefinition }: Pro
 			const v = sp.get(f.name) ?? f.defaultValue ?? ""
 			if (v) fieldsPayload[f.name] = v
 		}
-		fieldsPayload._hp_email = honeypotRef.current?.value || ""
+		fieldsPayload._hp_extra_field = honeypotRef.current?.value || ""
 
 		const communications = def.communicationConsentCheckboxes.map((c) => ({
 			subscriptionTypeId: c.communicationTypeId,
@@ -219,7 +219,11 @@ export const GetADemoClient = ({ hubspotForm, redirectURL, formDefinition }: Pro
 			const emailField = visibleFields.find(isEmailField)
 			const email = emailField ? (values[emailField.name] || "").trim() : ""
 			if (email) identify(email)
-			capture("website-form-submission", { name: formName })
+			// Send every submitted field to PostHog alongside the form name. We reuse
+			// fieldsPayload (visible + populated hidden fields, already trimmed),
+			// including the honeypot (_hp_extra_field) — a non-empty value there flags
+			// a submission the server silently dropped, so it's worth seeing in analytics.
+			capture("website-form-submission", { name: formName, ...fieldsPayload })
 
 			const target = redirectURL || def.redirectUrl
 			if (target) {
@@ -307,11 +311,17 @@ export const GetADemoClient = ({ hubspotForm, redirectURL, formDefinition }: Pro
 				)
 			})}
 
-			{/* Honeypot — hidden from users, catches bots (form has no captcha). */}
+			{/* Honeypot — hidden from users, catches bots (form has no captcha).
+			    The field name deliberately avoids autofill-magnet tokens like
+			    "email"/"name"/"phone"/"address": browser autofill and password
+			    managers match on the name attribute and will fill an off-screen
+			    field named e.g. `_hp_email` for a real human, tripping the trap.
+			    A neutral name (`_hp_extra_field`) keeps autofill away while bots,
+			    which fill everything, still get caught. */}
 			<div aria-hidden="true" className="absolute left-[-9999px] h-0 w-0 overflow-hidden">
 				<label>
 					Please leave this field empty
-					<input ref={honeypotRef} type="text" name="_hp_email" tabIndex={-1} autoComplete="off" />
+					<input ref={honeypotRef} type="text" name="_hp_extra_field" tabIndex={-1} autoComplete="off" />
 				</label>
 			</div>
 


### PR DESCRIPTION
### Problem
Marketing spotted visitors in Snitcher moving from /demo-request → /get-a-demo-step-2-book (the post-submit booking page) with no matching submission in HubSpot. The demo form's honeypot was silently eating legitimate leads.

The native HubSpot demo form (PR #86) uses a hidden honeypot field to catch bots. If that field is non-empty, the API route drops the submission but still returns success: true, so the visitor is redirected to step 2 as if it worked. The field was named _hp_email — and browser autofill / password managers match fields by their name attribute, so they filled the off-screen _hp_email field on behalf of real humans, tripping the trap. Business users (disproportionately on autofill/password managers) were the most affected, which matches Snitcher resolving these to real companies.

### Changes
1. Rename the honeypot _hp_email → _hp_extra_field (client input + payload key, and both references in the API route). The neutral name has no email/name/phone/address token for autofill heuristics to match, so autofill leaves it alone. Bots still trip it because they fill every field blindly regardless of name. Added a comment so it doesn't get "helpfully" renamed back.
2. Send all submitted fields to PostHog on website-form-submission (previously only the form name). Reuses the existing trimmed payload (visible fields + populated utm_* hidden fields).
Include the honeypot value in the PostHog event. A non-empty _hp_extra_field marks a submission the server silently dropped — so we can now measure the drop rate and audit false positives directly in PostHog, which is the signal that was missing when this bug went unnoticed.