### PR TITLE
auto generate decorators for web studio

### DIFF
--- a/components/agility-components/2BoxContent.tsx
+++ b/components/agility-components/2BoxContent.tsx
@@ -28,8 +28,10 @@ export const TwoBoxContent = async ({ module, languageCode }: UnloadedModuleProp
 	const darkMode = fields.darkMode === "true"
 
 	return (
-		<div className={clsx(darkMode ? "bg-black" : "bg-white")}>
-			<Container className="relative z-[2] mx-auto -mt-32 max-w-5xl">
+        <div
+            className={clsx(darkMode ? "bg-black" : "bg-white")}
+            data-agility-component={contentID}>
+            <Container className="relative z-[2] mx-auto -mt-32 max-w-5xl">
 				<div className={clsx("flex h-[500px] min-h-0 w-full flex-col justify-center gap-8 lg:flex-row")}>
 					{/* Box 1 */}
 					{fields.image && fields.heading && fields.cTA && fields.description && (
@@ -41,10 +43,10 @@ export const TwoBoxContent = async ({ module, languageCode }: UnloadedModuleProp
 								darkMode ? "bg-slate-800 text-white" : "bg-white"
 							)}
 						>
-							<AgilityPic image={fields.image} className="w-44" />
+							<AgilityPic image={fields.image} className="w-44" data-agility-field="image" />
 
-							<h3 className="text-balance text-4xl">{fields.heading}</h3>
-							<p className="flex-1">{fields.description}</p>
+							<h3 className="text-balance text-4xl" data-agility-field="heading">{fields.heading}</h3>
+							<p className="flex-1" data-agility-field="description">{fields.description}</p>
 							<div className="font-medium text-highlight-light">{fields.cTA.text}</div>
 						</Link>
 					)}
@@ -59,15 +61,18 @@ export const TwoBoxContent = async ({ module, languageCode }: UnloadedModuleProp
 								darkMode ? "bg-slate-800 text-white" : "bg-white"
 							)}
 						>
-							<AgilityPic image={fields.image2} className="w-44 object-contain" />
+							<AgilityPic
+                                image={fields.image2}
+                                className="w-44 object-contain"
+                                data-agility-field="image2" />
 
-							<h3 className="text-balance text-4xl">{fields.heading2}</h3>
-							<p className="flex-1">{fields.description2}</p>
+							<h3 className="text-balance text-4xl" data-agility-field="heading2">{fields.heading2}</h3>
+							<p className="flex-1" data-agility-field="description2">{fields.description2}</p>
 							<div className="font-medium text-highlight-light">{fields.cTA2.text}</div>
 						</Link>
 					)}
 				</div>
 			</Container>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/CTABlocks.tsx
+++ b/components/agility-components/CTABlocks.tsx
@@ -36,33 +36,41 @@ export const CTABlocks = async ({ module, languageCode }: UnloadedModuleProps) =
 	const blocks = lstBlocks.items as ContentItem<Block>[]
 
 	return (
-		<Container
+        <Container
 			id={`agility-component-${module.contentid}`}
 			data-agility-component={module.contentid}
 
 		>
-			<div className="mx-auto max-w-7xl">
-				<h2 className="text-center text-5xl font-medium">{fields.heading}</h2>
+            <div className="mx-auto max-w-7xl">
+				<h2 className="text-center text-5xl font-medium" data-agility-field="heading">{fields.heading}</h2>
 				<ThreeDashLine />
-				<h3 className="mt-5 text-center text-xl font-medium">{fields.subHeading}</h3>
+				<h3
+                    className="mt-5 text-center text-xl font-medium"
+                    data-agility-field="subHeading">{fields.subHeading}</h3>
 
 				<div className="mt-10 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
 					{blocks.map((block, index) => (
 						<Link
-							href={block.fields.link.href}
-							target={block.fields.link.target}
-							key={block.contentID}
-							className="rounded-lg border border-background/50 bg-white p-5 shadow-md transition-shadow hover:shadow-lg"
-						>
+                            href={block.fields.link.href}
+                            target={block.fields.link.target}
+                            key={block.contentID}
+                            className="rounded-lg border border-background/50 bg-white p-5 shadow-md transition-shadow hover:shadow-lg"
+                            data-agility-component={block.contentID}
+                            data-agility-field="link">
 							{block.fields.image && (
-								<AgilityPic image={block.fields.image} className="h-40 w-full rounded-lg object-contain" />
+								<AgilityPic
+                                    image={block.fields.image}
+                                    className="h-40 w-full rounded-lg object-contain"
+                                    data-agility-field="image" />
 							)}
-							<h4 className="mt-5 text-balance text-center text-xl font-medium">{block.fields.title}</h4>
-							<p className="mt-3 text-balance text-center">{block.fields.subtitle}</p>
+							<h4
+                                className="mt-5 text-balance text-center text-xl font-medium"
+                                data-agility-field="title">{block.fields.title}</h4>
+							<p className="mt-3 text-balance text-center" data-agility-field="subtitle">{block.fields.subtitle}</p>
 						</Link>
 					))}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/CalendlyScheduler/CalendlyScheduler.tsx
+++ b/components/agility-components/CalendlyScheduler/CalendlyScheduler.tsx
@@ -17,29 +17,34 @@ export const CalendlyScheduler = async ({ module, languageCode }: UnloadedModule
 	})
 
 	return (
-		<div
-			id="scheduler-page"
-			//className="bg-background/40"
-			style={{
+        <div
+            id="scheduler-page"
+            //className="bg-background/40"
+            style={{
 				// backgroundImage: "url(/images/icon-agility.svg)",
 				// backgroundRepeat: "no-repeat",
 				// backgroundPosition: "left bottom"
 			}}
-		>
-			<Container className="mx-auto flex max-w-7xl">
+            data-agility-component={contentID}>
+            <Container className="mx-auto flex max-w-7xl">
 				<div className="flex w-full flex-col gap-5 lg:flex-row">
 					<div className="lg:w-2/5">
 						<div
-							className="prose lg:prose-lg"
-							dangerouslySetInnerHTML={renderHTMLCustom(fields.leftPanelContent)}
-						></div>
+                            className="prose lg:prose-lg"
+                            dangerouslySetInnerHTML={renderHTMLCustom(fields.leftPanelContent)}
+                            data-agility-field="leftPanelContent"
+                            data-agility-html></div>
 					</div>
 					<div className="lg:w-3/5">
-						<div className="calendly-inline-widget px-3 -mt-10" data-url={fields.iFrameURL} style={{ minWidth: "320px", height: "1100px" }}></div>
+						<div
+                            className="calendly-inline-widget px-3 -mt-10"
+                            data-url={fields.iFrameURL}
+                            style={{ minWidth: "320px", height: "1100px" }}
+                            data-agility-field="iFrameURL"></div>
 					</div>
 				</div>
 			</Container>
-			<Script src="https://assets.calendly.com/assets/external/widget.js" strategy="afterInteractive" async />
-		</div>
-	)
+            <Script src="https://assets.calendly.com/assets/external/widget.js" strategy="afterInteractive" async />
+        </div>
+    );
 }

--- a/components/agility-components/Carousel/Carousel.tsx
+++ b/components/agility-components/Carousel/Carousel.tsx
@@ -40,12 +40,16 @@ export const Carousel = async ({ module, languageCode }: UnloadedModuleProps) =>
 	const items: ContentItem<ICarouselItem>[] = lst.items
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-5xl">
-				<h2 className="text-balance text-center text-3xl font-medium">{fields.heading}</h2>
-				<div className="mt-5 text-balance text-center text-xl font-medium">{fields.subheading}</div>
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-5xl">
+				<h2
+                    className="text-balance text-center text-3xl font-medium"
+                    data-agility-field="heading">{fields.heading}</h2>
+				<div
+                    className="mt-5 text-balance text-center text-xl font-medium"
+                    data-agility-field="subheading">{fields.subheading}</div>
 			</div>
-			<CarouselClient {...{ items: items }} />
-		</Container>
-	)
+            <CarouselClient {...{ items: items }} />
+        </Container>
+    );
 }

--- a/components/agility-components/CaseStudyDetails/CaseStudyDetails.tsx
+++ b/components/agility-components/CaseStudyDetails/CaseStudyDetails.tsx
@@ -61,8 +61,8 @@ export const CaseStudyDetails = async ({ dynamicPageItem, languageCode, module }
 			}) || []
 
 	return (
-		<>
-			<Container >
+        <>
+            <Container >
 				<div className="mx-auto max-w-7xl">
 					<div className="lg:flex lg:flex-row-reverse">
 						<div className="bg-background/60 p-6 lg:w-1/3 lg:bg-white lg:p-0">
@@ -154,33 +154,35 @@ export const CaseStudyDetails = async ({ dynamicPageItem, languageCode, module }
 					</div>
 				</div>
 			</Container>
-
-			{/* Related Case Studies */}
-			{minCaseStudies.length > 0 && (
+            {/* Related Case Studies */}
+            {minCaseStudies.length > 0 && (
 				<Container id={`${contentID}`} data-agility-component={contentID}>
 					<div className="mx-auto max-w-5xl text-center">
-						<h2 className="text-center text-3xl font-medium">{fields.relatedCaseStudiesHeading}</h2>
+						<h2
+                            className="text-center text-3xl font-medium"
+                            data-agility-field="relatedCaseStudiesHeading">{fields.relatedCaseStudiesHeading}</h2>
 					</div>
 					<CaseStudyRotatorClient
-						{...{ caseStudies: minCaseStudies, cTAbuttonText: fields.relatedCaseStudiesCTALabel }}
-					/>
+                        {...{ caseStudies: minCaseStudies, cTAbuttonText: fields.relatedCaseStudiesCTALabel }}
+                        data-agility-field="relatedCaseStudiesCTALabel" />
 				</Container>
 			)}
-
-			<Container >
+            <Container >
 				<div className="mx-auto max-w-7xl">
 					{/* related resources */}
 					{caseStudy.relatedResources && caseStudy.relatedResources.length > 0 && (
 						<div className="mt-10">
-							<h2 className="text-center text-3xl font-medium">{fields.relatedResourcesHeading}</h2>
+							<h2
+                                className="text-center text-3xl font-medium"
+                                data-agility-field="relatedResourcesHeading">{fields.relatedResourcesHeading}</h2>
 							<div className="mt-6 flex w-full flex-col justify-center gap-6 lg:flex-row">
 								{caseStudy.relatedResources?.map((item) => (
 									<ResourceCard
-										key={item.contentID}
-										languageCode={languageCode}
-										resource={item.fields}
-										ctaLabel={fields.relatedResourcesCTALabel}
-									/>
+                                        key={item.contentID}
+                                        languageCode={languageCode}
+                                        resource={item.fields}
+                                        ctaLabel={fields.relatedResourcesCTALabel}
+                                        data-agility-field="relatedResourcesCTALabel" />
 								))}
 							</div>
 						</div>
@@ -210,6 +212,6 @@ export const CaseStudyDetails = async ({ dynamicPageItem, languageCode, module }
 					</div>
 				</div>
 			</Container>
-		</>
-	)
+        </>
+    );
 }

--- a/components/agility-components/CaseStudyListing/CaseStudyListing.tsx
+++ b/components/agility-components/CaseStudyListing/CaseStudyListing.tsx
@@ -116,8 +116,8 @@ export const CaseStudyListing = async ({ module, languageCode, globalData }: Unl
 	}
 
 	return (
-		<CaseStudyListingClient
-			{...{
+        <CaseStudyListingClient
+            {...{
 				caseCount,
 				getNextItems,
 				industryQStr,
@@ -136,6 +136,6 @@ export const CaseStudyListing = async ({ module, languageCode, globalData }: Unl
 						value: c.contentID
 					})) || []
 			}}
-		/>
-	)
+            data-agility-component={contentID} />
+    );
 }

--- a/components/agility-components/CaseStudyRotator/CaseStudyRotator.tsx
+++ b/components/agility-components/CaseStudyRotator/CaseStudyRotator.tsx
@@ -72,13 +72,15 @@ const CaseStudyRotator = async ({ module, languageCode }: UnloadedModuleProps) =
 		})
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-5xl text-center">
-				{title && <h2 className="text-balance text-4xl">{title}</h2>}
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-5xl text-center">
+				{title && <h2 className="text-balance text-4xl" data-agility-field="title">{title}</h2>}
 			</div>
-			<CaseStudyRotatorClient {...{ caseStudies: minCaseStudies, cTAbuttonText: fields.cTAbuttonText }} />
-		</Container>
-	)
+            <CaseStudyRotatorClient
+                {...{ caseStudies: minCaseStudies, cTAbuttonText: fields.cTAbuttonText }}
+                data-agility-field="cTAbuttonText" />
+        </Container>
+    );
 }
 
 export default CaseStudyRotator

--- a/components/agility-components/CenteredCTAPanel.tsx
+++ b/components/agility-components/CenteredCTAPanel.tsx
@@ -25,32 +25,36 @@ const CenteredCTAPanel = async ({ module, languageCode }: UnloadedModuleProps) =
 	const darkMode = fields.darkMode === "true"
 
 	return (
-		<Container
+        <Container
 			id={`${contentID}`}
 			data-agility-component={contentID}
 			className={clsx("relative overflow-clip pb-14 text-white", darkMode ? "bg-black" : "bg-highlight mt-14")}
 		>
-			<div
+            <div
 				className={clsx("absolute -top-7 h-12 w-12 rotate-45", darkMode ? "bg-secondary" : "bg-white")}
 				style={{ left: "calc(50% - 24px)" }}
 			></div>
-			<div className="mx-auto max-w-5xl pt-8 text-center">
-				{title && <h2 className="text-balance text-5xl">{title}</h2>}
+            <div className="mx-auto max-w-5xl pt-8 text-center">
+				{title && <h2 className="text-balance text-5xl" data-agility-field="title">{title}</h2>}
 				<ThreeDashLine />
 				{description && (
-					<div className="mt-2 text-balance text-xl" dangerouslySetInnerHTML={renderHTMLCustom(description)} />
+					<div
+                        className="mt-2 text-balance text-xl"
+                        dangerouslySetInnerHTML={renderHTMLCustom(description)}
+                        data-agility-field="description"
+                        data-agility-html />
 				)}
 				{(cTA1 || cTA2) && (
 					<div className="mt-8 flex items-center justify-center gap-2">
 						{cTA1 && cTA1.href && (
 							<>
 								<LinkButton
-									type={darkMode ? "alternate" : "alternate"}
-									href={cTA1.href}
-									target={cTA1.target}
-									//className={clsx("", darkMode ? "text-black" : "!bg-white")}
-									size="lg"
-								>
+                                    type={darkMode ? "alternate" : "alternate"}
+                                    href={cTA1.href}
+                                    target={cTA1.target}
+                                    //className={clsx("", darkMode ? "text-black" : "!bg-white")}
+                                    size="lg"
+                                    data-agility-field="cTA1">
 									{cTA1.text} <IconChevronRight />
 								</LinkButton>
 							</>
@@ -58,20 +62,20 @@ const CenteredCTAPanel = async ({ module, languageCode }: UnloadedModuleProps) =
 
 						{cTA2 && cTA2.href && (
 							<LinkButton
-								type={darkMode ? "secondary-inverted" : "secondary"}
-								href={cTA2.href}
-								target={cTA2.target}
-								className={clsx(darkMode ? "!bg-black/0" : "!bg-white")}
-								size="lg"
-							>
+                                type={darkMode ? "secondary-inverted" : "secondary"}
+                                href={cTA2.href}
+                                target={cTA2.target}
+                                className={clsx(darkMode ? "!bg-black/0" : "!bg-white")}
+                                size="lg"
+                                data-agility-field="cTA2">
 								{cTA2.text}
 							</LinkButton>
 						)}
 					</div>
 				)}
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }
 
 export default CenteredCTAPanel

--- a/components/agility-components/CompareHero/CompareHero.tsx
+++ b/components/agility-components/CompareHero/CompareHero.tsx
@@ -41,11 +41,15 @@ export const CompareHero = async ({ module, languageCode }: UnloadedModuleProps)
 	const stats = (lstStats?.items || []) as ContentItem<ICompareHeroStat>[]
 
 	return (
-		<div className="bg-linear-to-b from-[#f8f4ff] to-white">
-			<Container id={`${contentID}`} data-agility-component={contentID}>
+        <div
+            className="bg-linear-to-b from-[#f8f4ff] to-white"
+            data-agility-component={contentID}>
+            <Container id={`${contentID}`} data-agility-component={contentID}>
 				<div className="mx-auto max-w-4xl pb-16 text-center md:pb-24">
 					{fields.label && (
-						<div className="mb-6 inline-flex items-center gap-2 rounded-full border border-highlight-light/20 bg-highlight-light/5 px-3 py-1 text-xs font-semibold text-highlight-light">
+						<div
+                            className="mb-6 inline-flex items-center gap-2 rounded-full border border-highlight-light/20 bg-highlight-light/5 px-3 py-1 text-xs font-semibold text-highlight-light"
+                            data-agility-field="label">
 							{fields.label}
 						</div>
 					)}
@@ -53,24 +57,38 @@ export const CompareHero = async ({ module, languageCode }: UnloadedModuleProps)
 						<h1 className="mx-auto max-w-4xl text-balance text-4xl font-extrabold leading-[1.1] tracking-tight text-black sm:text-5xl lg:text-6xl">
 							{fields.heading}{" "}
 							{fields.highlightedText && (
-								<span className="text-highlight">{fields.highlightedText}</span>
+								<span className="text-highlight" data-agility-field="highlightedText">{fields.highlightedText}</span>
 							)}
 						</h1>
 					)}
 					{fields.description && (
-						<p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-gray-500">
+						<p
+                            className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-gray-500"
+                            data-agility-field="description">
 							{fields.description}
 						</p>
 					)}
 					{(fields.primaryCTA || fields.secondaryCTA) && (
 						<div className="mt-8 flex flex-wrap items-center justify-center gap-4">
 							{fields.primaryCTA && fields.primaryCTA.href && (
-								<LinkButton type="alternate" size="lg" href={fields.primaryCTA.href} target={fields.primaryCTA.target} className="rounded-full px-10 text-base font-bold shadow-md">
+								<LinkButton
+                                    type="alternate"
+                                    size="lg"
+                                    href={fields.primaryCTA.href}
+                                    target={fields.primaryCTA.target}
+                                    className="rounded-full px-10 text-base font-bold shadow-md"
+                                    data-agility-field="primaryCTA">
 									{fields.primaryCTA.text} <IconArrowRight className="ml-2 h-4 w-4" />
 								</LinkButton>
 							)}
 							{fields.secondaryCTA && fields.secondaryCTA.href && (
-								<LinkButton type="secondary" size="lg" href={fields.secondaryCTA.href} target={fields.secondaryCTA.target} className="rounded-full px-8 text-base font-medium">
+								<LinkButton
+                                    type="secondary"
+                                    size="lg"
+                                    href={fields.secondaryCTA.href}
+                                    target={fields.secondaryCTA.target}
+                                    className="rounded-full px-8 text-base font-medium"
+                                    data-agility-field="secondaryCTA">
 									{fields.secondaryCTA.text}
 								</LinkButton>
 							)}
@@ -78,8 +96,7 @@ export const CompareHero = async ({ module, languageCode }: UnloadedModuleProps)
 					)}
 				</div>
 			</Container>
-
-			{stats.length > 0 && (
+            {stats.length > 0 && (
 				<div className="border-y border-gray-200/40 bg-white py-8">
 					<div className="mx-auto grid max-w-4xl grid-cols-2 gap-6 px-4 text-center md:grid-cols-4">
 						{stats.map((stat) => (
@@ -93,6 +110,6 @@ export const CompareHero = async ({ module, languageCode }: UnloadedModuleProps)
 					</div>
 				</div>
 			)}
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/ComparisonTable/ComparisonTable.tsx
+++ b/components/agility-components/ComparisonTable/ComparisonTable.tsx
@@ -178,11 +178,13 @@ export const ComparisonTable = async ({ module, languageCode }: UnloadedModulePr
 	}
 
 	return (
-		<Container id={fields.anchorId || `${contentID}`} data-agility-component={contentID} className="bg-[#f8f4ff]">
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container id={fields.anchorId || `${contentID}`} data-agility-component={contentID} className="bg-[#f8f4ff]">
+            <div className="mx-auto max-w-7xl pb-14">
 				<div className="mb-10 text-center">
 					{fields.label && (
-						<p className="mb-3 text-xs font-bold uppercase tracking-[0.18em] text-highlight-light/70">
+						<p
+                            className="mb-3 text-xs font-bold uppercase tracking-[0.18em] text-highlight-light/70"
+                            data-agility-field="label">
 							{fields.label}
 						</p>
 					)}
@@ -190,22 +192,26 @@ export const ComparisonTable = async ({ module, languageCode }: UnloadedModulePr
 						<h2 className="mb-3 text-balance text-3xl font-extrabold text-primary sm:text-4xl">
 							{fields.heading}{" "}
 							{fields.highlightedText && (
-								<span className="italic text-highlight-light">{fields.highlightedText}</span>
+								<span
+                                    className="italic text-highlight-light"
+                                    data-agility-field="highlightedText">{fields.highlightedText}</span>
 							)}
 						</h2>
 					)}
 					{fields.description && (
-						<p className="mx-auto mb-6 max-w-xl text-gray-500">{fields.description}</p>
+						<p
+                            className="mx-auto mb-6 max-w-xl text-gray-500"
+                            data-agility-field="description">{fields.description}</p>
 					)}
 				</div>
 
 				<ComparisonTableClient
-					platforms={platformList}
-					rows={rows}
-					footnote={fields.footnote}
-					hideLegend={fields.hideLegend == "true"}
-				/>
+                    platforms={platformList}
+                    rows={rows}
+                    footnote={fields.footnote}
+                    hideLegend={fields.hideLegend == "true"}
+                    data-agility-field="footnote" />
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/CompetitorCards/CompetitorCards.tsx
+++ b/components/agility-components/CompetitorCards/CompetitorCards.tsx
@@ -43,16 +43,18 @@ export const CompetitorCards = async ({ module, languageCode }: UnloadedModulePr
 	const competitors = lstCompetitors.items as ContentItem<ICompetitorCard>[]
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID} className="bg-white">
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID} className="bg-white">
+            <div className="mx-auto max-w-7xl pb-14">
 				<div className="mb-10 max-w-2xl">
 					{fields.heading && (
-						<h2 className="text-balance text-4xl font-bold text-primary lg:text-5xl">
+						<h2
+                            className="text-balance text-4xl font-bold text-primary lg:text-5xl"
+                            data-agility-field="heading">
 							{fields.heading}
 						</h2>
 					)}
 					{fields.description && (
-						<p className="mt-3 text-gray-600">{fields.description}</p>
+						<p className="mt-3 text-gray-600" data-agility-field="description">{fields.description}</p>
 					)}
 				</div>
 
@@ -71,16 +73,18 @@ export const CompetitorCards = async ({ module, languageCode }: UnloadedModulePr
 							<div className="group flex h-full flex-col rounded-2xl border border-gray-200/60 bg-white p-5 shadow-sm transition-all duration-200 hover:border-primary/30 hover:shadow-lg">
 								<div className="mb-3 flex items-center gap-3">
 									<div
-										className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-sm font-bold text-white"
-										style={{ backgroundColor: avatarColor }}
-									>
+                                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-sm font-bold text-white"
+                                        style={{ backgroundColor: avatarColor }}
+                                        data-agility-field="avatarColor">
 										{initial}
 									</div>
-									<h3 className="text-base font-bold text-primary">
+									<h3 className="text-base font-bold text-primary" data-agility-field="title">
 										{comp.fields.title}
 									</h3>
 								</div>
-								<p className="flex-1 text-sm leading-relaxed text-gray-600">
+								<p
+                                    className="flex-1 text-sm leading-relaxed text-gray-600"
+                                    data-agility-field="description">
 									{comp.fields.description}
 								</p>
 								{painPoints.length > 0 && (
@@ -105,16 +109,20 @@ export const CompetitorCards = async ({ module, languageCode }: UnloadedModulePr
 
 						if (comp.fields.link && comp.fields.link.href) {
 							return (
-								<Link key={comp.contentID} href={comp.fields.link.href} target={comp.fields.link.target}>
-									{cardContent}
-								</Link>
-							)
+                                <Link
+                                    key={comp.contentID}
+                                    href={comp.fields.link.href}
+                                    target={comp.fields.link.target}
+                                    data-agility-component={comp.contentID}>
+                                    {cardContent}
+                                </Link>
+                            );
 						}
 
-						return <div key={comp.contentID}>{cardContent}</div>
+						return <div key={comp.contentID} data-agility-component={comp.contentID}>{cardContent}</div>;
 					})}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/CustomerResults/CustomerResults.tsx
+++ b/components/agility-components/CustomerResults/CustomerResults.tsx
@@ -38,10 +38,12 @@ export const CustomerResults = async ({ module, languageCode }: UnloadedModulePr
 	const results = lstResults.items as ContentItem<ICustomerResult>[]
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID} className="bg-gray-50 border-b border-gray-200">
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID} className="bg-gray-50 border-b border-gray-200">
+            <div className="mx-auto max-w-7xl pb-14">
 				{fields.heading && (
-					<h2 className="text-balance text-center text-sm font-semibold uppercase tracking-widest text-gray-500">
+					<h2
+                        className="text-balance text-center text-sm font-semibold uppercase tracking-widest text-gray-500"
+                        data-agility-field="heading">
 						{fields.heading}
 					</h2>
 				)}
@@ -75,16 +77,20 @@ export const CustomerResults = async ({ module, languageCode }: UnloadedModulePr
 
 						if (link && link.href) {
 							return (
-								<Link key={item.contentID} href={link.href} target={link.target}>
-									{cardContent}
-								</Link>
-							)
+                                <Link
+                                    key={item.contentID}
+                                    href={link.href}
+                                    target={link.target}
+                                    data-agility-component={item.contentID}>
+                                    {cardContent}
+                                </Link>
+                            );
 						}
 
-						return <div key={item.contentID}>{cardContent}</div>
+						return <div key={item.contentID} data-agility-component={item.contentID}>{cardContent}</div>;
 					})}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/DualCTABanner/DualCTABanner.tsx
+++ b/components/agility-components/DualCTABanner/DualCTABanner.tsx
@@ -17,20 +17,24 @@ export const DualCTABanner = async ({ module, languageCode }: UnloadedModuleProp
 	})
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-5xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-5xl pb-14">
 				<div className="relative overflow-hidden rounded-3xl bg-gray-50 p-12 text-center md:p-20">
 					{/* Decorative background shapes */}
 					<div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-gray-100/40 via-transparent to-purple-100/40" />
 					<div className="pointer-events-none absolute -bottom-44 -left-36 h-[430px] w-[430px] rounded-full bg-gray-200/50" />
 					<div className="pointer-events-none absolute -right-36 -top-44 h-[430px] w-[430px] rounded-full bg-purple-100/50" />
 					{fields.heading && (
-						<h2 className="relative text-balance text-4xl font-extrabold text-primary md:text-5xl">
+						<h2
+                            className="relative text-balance text-4xl font-extrabold text-primary md:text-5xl"
+                            data-agility-field="heading">
 							{fields.heading}
 						</h2>
 					)}
 					{fields.description && (
-						<p className="relative mx-auto mt-4 max-w-2xl text-balance text-lg text-gray-600">
+						<p
+                            className="relative mx-auto mt-4 max-w-2xl text-balance text-lg text-gray-600"
+                            data-agility-field="description">
 							{fields.description}
 						</p>
 					)}
@@ -38,19 +42,19 @@ export const DualCTABanner = async ({ module, languageCode }: UnloadedModuleProp
 						<div className="relative mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
 							{fields.primaryCTA && fields.primaryCTA.href && (
 								<Link
-									href={fields.primaryCTA.href}
-									target={fields.primaryCTA.target}
-									className="inline-flex h-12 items-center justify-center rounded-full bg-secondary px-8 text-lg font-medium text-gray-900 transition-all duration-200 hover:scale-105 hover:bg-secondary/90"
-								>
+                                    href={fields.primaryCTA.href}
+                                    target={fields.primaryCTA.target}
+                                    className="inline-flex h-12 items-center justify-center rounded-full bg-secondary px-8 text-lg font-medium text-gray-900 transition-all duration-200 hover:scale-105 hover:bg-secondary/90"
+                                    data-agility-field="primaryCTA">
 									{fields.primaryCTA.text}
 								</Link>
 							)}
 							{fields.secondaryCTA && fields.secondaryCTA.href && (
 								<Link
-									href={fields.secondaryCTA.href}
-									target={fields.secondaryCTA.target}
-									className="inline-flex h-12 items-center justify-center rounded-full border border-gray-800 bg-white px-8 text-lg font-medium text-gray-900 transition-all duration-200 hover:scale-105 hover:bg-gray-50"
-								>
+                                    href={fields.secondaryCTA.href}
+                                    target={fields.secondaryCTA.target}
+                                    className="inline-flex h-12 items-center justify-center rounded-full border border-gray-800 bg-white px-8 text-lg font-medium text-gray-900 transition-all duration-200 hover:scale-105 hover:bg-gray-50"
+                                    data-agility-field="secondaryCTA">
 									{fields.secondaryCTA.text}
 								</Link>
 							)}
@@ -58,6 +62,6 @@ export const DualCTABanner = async ({ module, languageCode }: UnloadedModuleProp
 					)}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/EventListing/EventListing.server.tsx
+++ b/components/agility-components/EventListing/EventListing.server.tsx
@@ -68,13 +68,17 @@ export const EventListing = async ({ module, languageCode }: UnloadedModuleProps
 	if (events.length === 0) return
 
 	return (
-		<Container >
-			<div className="mx-auto max-w-7xl">
-				<h2 className="text-center text-5xl font-medium">{fields.title}</h2>
+        <Container data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
+				<h2 className="text-center text-5xl font-medium" data-agility-field="title">{fields.title}</h2>
 				<ThreeDashLine />
-				<div className="prose prose-lg mx-auto mt-5" dangerouslySetInnerHTML={renderHTMLCustom(fields.subTitle)}></div>
+				<div
+                    className="prose prose-lg mx-auto mt-5"
+                    dangerouslySetInnerHTML={renderHTMLCustom(fields.subTitle)}
+                    data-agility-field="subTitle"
+                    data-agility-html></div>
 				<EventListingClient {...{ events, locale, getNext, pageSize }} />
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/Faqs.tsx
+++ b/components/agility-components/Faqs.tsx
@@ -38,19 +38,25 @@ export const Faqs = async ({ module, languageCode }: UnloadedModuleProps) => {
 	const faqs = lstFaqs.items as ContentItem<Faq>[]
 
 	return (
-		<div className="bg-background/60 pb-14">
-			<Container className="mx-auto max-w-5xl">
+        <div className="bg-background/60 pb-14" data-agility-component={contentID}>
+            <Container className="mx-auto max-w-5xl">
 				{fields.label && (
-					<p className="mb-3 text-center text-xs font-bold uppercase tracking-[0.18em] text-primary/70">
+					<p
+                        className="mb-3 text-center text-xs font-bold uppercase tracking-[0.18em] text-primary/70"
+                        data-agility-field="label">
 						{fields.label}
 					</p>
 				)}
-				<h2 className="text-balance text-center text-5xl">{fields.title}</h2>
+				<h2 className="text-balance text-center text-5xl" data-agility-field="title">{fields.title}</h2>
 				<dl className="mt-8">
 					{faqs.map((faq) => {
 						return (
-							<>
-								<Disclosure as="div" key={faq.contentID} className="group">
+                            <>
+                                <Disclosure
+                                    as="div"
+                                    key={faq.contentID}
+                                    className="group"
+                                    data-agility-component={faq.contentID}>
 									<DisclosureButton className={clsx("w-full text-left flex gap-2 items-center hover:text-highlight-light transition-colors")}>
 										<div className="">
 											<IconChevronRight
@@ -58,7 +64,7 @@ export const Faqs = async ({ module, languageCode }: UnloadedModuleProps) => {
 												className="h-5 w-5 transition-transform duration-300 ease-in-out group-data-[open]:rotate-90"
 											/>
 										</div>
-										<dt className="text-lg font-medium ">
+										<dt className="text-lg font-medium " data-agility-field="question">
 											{faq.fields.question}
 										</dt>
 									</DisclosureButton>
@@ -68,17 +74,18 @@ export const Faqs = async ({ module, languageCode }: UnloadedModuleProps) => {
 											className="origin-top transition duration-200 ease-out data-[closed]:-translate-y-6 data-[closed]:opacity-0"
 										>
 											<dd
-												className="prose max-w-full pb-6 ml-9"
-												dangerouslySetInnerHTML={renderHTMLCustom(faq.fields.answer)}
-											></dd>
+                                                className="prose max-w-full pb-6 ml-9"
+                                                dangerouslySetInnerHTML={renderHTMLCustom(faq.fields.answer)}
+                                                data-agility-field="answer"
+                                                data-agility-html></dd>
 										</DisclosurePanel>
 									</div>
 								</Disclosure>
-							</>
-						)
+                            </>
+                        );
 					})}
 				</dl>
 			</Container>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/FeaturedResources.tsx
+++ b/components/agility-components/FeaturedResources.tsx
@@ -42,8 +42,8 @@ const FeaturedResources = async ({ module, languageCode }: UnloadedModuleProps) 
 	if (!lstResources || lstResources.length === 0) return null
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-5xl text-center">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-5xl text-center" data-agility-field="title">
 				{title && <h2 className="text-balance text-5xl">{title}</h2>}
 				<ThreeDashLine />
 
@@ -89,8 +89,8 @@ const FeaturedResources = async ({ module, languageCode }: UnloadedModuleProps) 
 						})}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }
 
 export default FeaturedResources

--- a/components/agility-components/G2AwardsBanner/G2AwardsBanner.tsx
+++ b/components/agility-components/G2AwardsBanner/G2AwardsBanner.tsx
@@ -14,28 +14,30 @@ export const G2AwardsBanner = async ({ module, languageCode }: UnloadedModulePro
 	})
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-5xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-5xl pb-14">
 				{fields.heading && (
-					<h2 className="text-balance text-center text-4xl font-bold text-primary lg:text-5xl">
+					<h2
+                        className="text-balance text-center text-4xl font-bold text-primary lg:text-5xl"
+                        data-agility-field="heading">
 						{fields.heading}
 					</h2>
 				)}
 				{fields.badgesImage && (
 					<div className="mt-10 overflow-hidden rounded-2xl bg-white p-6 shadow-lg lg:p-10">
 						<AgilityPic
-							image={fields.badgesImage}
-							className="w-full"
-							fallbackWidth={900}
-							sources={[
+                            image={fields.badgesImage}
+                            className="w-full"
+                            fallbackWidth={900}
+                            sources={[
 								{ media: "(min-width: 1200px)", width: 1000 },
 								{ media: "(min-width: 768px)", width: 800 },
 								{ media: "(min-width: 640px)", width: 600 },
 							]}
-						/>
+                            data-agility-field="badgesImage" />
 					</div>
 				)}
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/G2CrowdReviewListing/G2CrowdReviewListing.tsx
+++ b/components/agility-components/G2CrowdReviewListing/G2CrowdReviewListing.tsx
@@ -22,17 +22,17 @@ export const G2CrowdReviewListing = async ({ module, languageCode }: UnloadedMod
 	const { heading } = fields
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-5xl text-center">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-5xl text-center">
 				{heading && (
 					<>
-						<h1 className="text-balance text-5xl">{heading}</h1>
+						<h1 className="text-balance text-5xl" data-agility-field="heading">{heading}</h1>
 						<ThreeDashLine />
 					</>
 				)}
 
 				<G2CrowdReviewListingClient {...fields} />
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/GartnerPeerInsightsBar.tsx
+++ b/components/agility-components/GartnerPeerInsightsBar.tsx
@@ -19,8 +19,8 @@ export const GartnerPeerInsightsBar = async ({ module, languageCode }: UnloadedM
 	})
 
 	return (
-		<div className="pt-14">
-			<div className="relative items-center bg-gradient-to-r from-highlight to-highlight-dark p-8">
+        <div className="pt-14" data-agility-component={contentID}>
+            <div className="relative items-center bg-gradient-to-r from-highlight to-highlight-dark p-8">
 				<div className="absolute left-0 h-full overflow-clip">
 					<img src="https://static.agilitycms.com/layout/static/bg-top.svg" alt="" />
 				</div>
@@ -30,22 +30,35 @@ export const GartnerPeerInsightsBar = async ({ module, languageCode }: UnloadedM
 				<div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-3 lg:flex-row">
 					<div className="flex flex-1 flex-col items-center gap-5 md:flex-row">
 						<div className="h-12 border-r border-r-white/20 pr-5">
-							<AgilityPic image={fields.gartnerLogo} className="h-full object-contain" fallbackWidth={400} />
+							<AgilityPic
+                                image={fields.gartnerLogo}
+                                className="h-full object-contain"
+                                fallbackWidth={400}
+                                data-agility-field="gartnerLogo" />
 						</div>
 						<div className="h-6">
-							<AgilityPic image={fields.starsGraphic} className="h-full object-contain" fallbackWidth={300} />
+							<AgilityPic
+                                image={fields.starsGraphic}
+                                className="h-full object-contain"
+                                fallbackWidth={300}
+                                data-agility-field="starsGraphic" />
 						</div>
 						<div>
-							<h3 className="text-lg font-medium text-white">{fields.title}</h3>
+							<h3 className="text-lg font-medium text-white" data-agility-field="title">{fields.title}</h3>
 						</div>
 					</div>
 					<div>
-						<LinkButton type="primary" size="lg" href={fields.cTAButton.href} target={fields.cTAButton.target}>
+						<LinkButton
+                            type="primary"
+                            size="lg"
+                            href={fields.cTAButton.href}
+                            target={fields.cTAButton.target}
+                            data-agility-field="cTAButton">
 							{fields.cTAButton.text}
 						</LinkButton>
 					</div>
 				</div>
 			</div>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/GatedDownload/GatedDownload.tsx
+++ b/components/agility-components/GatedDownload/GatedDownload.tsx
@@ -19,16 +19,25 @@ export const GatedDownload = async ({ module, languageCode }: UnloadedModuleProp
 	})
 
 	return (
-		<Container className="mx-auto flex max-w-7xl flex-col gap-10 lg:flex-row">
-			<div className="lg:w-1/2">
-				<h2 className="text-balance text-4xl font-medium">{fields.leftColumnTitle}</h2>
-				<div className="prose mt-10" dangerouslySetInnerHTML={renderHTMLCustom(fields.leftColumnBody)}></div>
+        <Container className="mx-auto flex max-w-7xl flex-col gap-10 lg:flex-row">
+            <div className="lg:w-1/2">
+				<h2
+                    className="text-balance text-4xl font-medium"
+                    data-agility-field="leftColumnTitle">{fields.leftColumnTitle}</h2>
+				<div
+                    className="prose mt-10"
+                    dangerouslySetInnerHTML={renderHTMLCustom(fields.leftColumnBody)}
+                    data-agility-field="leftColumnBody"
+                    data-agility-html></div>
 			</div>
-			<div className="lg:w-1/2">
+            <div className="lg:w-1/2">
 				<div className="border-t-4 border-t-highlight-light p-6 shadow-lg">
-					<GatedDownloadClient redirectURL={fields.redirectURL.href} hubspotForm={fields.hubspotForm} />
+					<GatedDownloadClient
+                        redirectURL={fields.redirectURL.href}
+                        hubspotForm={fields.hubspotForm}
+                        data-agility-field="redirectURL" />
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/GetADemo/GetADemo.tsx
+++ b/components/agility-components/GetADemo/GetADemo.tsx
@@ -56,14 +56,18 @@ export const GetADemo = async ({ module, languageCode }: UnloadedModuleProps) =>
 	const hasVideo = vimeoVideoData && (vimeoVideoData.video_id || vimeoVideoData.url)
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-6xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-6xl pb-14">
 				{/* Heading + Subheading */}
 				{fields.heading && (
 					<div className="mb-10 text-center">
-						<h1 className="text-balance text-5xl font-medium">{fields.heading}</h1>
+						<h1
+                            className="text-balance text-5xl font-medium"
+                            data-agility-field="heading">{fields.heading}</h1>
 						{fields.subHeading && (
-							<p className="mx-auto mt-4 max-w-2xl text-lg text-gray-600">{fields.subHeading}</p>
+							<p
+                                className="mx-auto mt-4 max-w-2xl text-lg text-gray-600"
+                                data-agility-field="subHeading">{fields.subHeading}</p>
 						)}
 					</div>
 				)}
@@ -80,16 +84,18 @@ export const GetADemo = async ({ module, languageCode }: UnloadedModuleProps) =>
 
 						{fields.leftContent && (
 							<div
-								className="prose max-w-none overflow-hidden rounded-lg [&_iframe]:aspect-video [&_iframe]:w-full [&_iframe]:rounded-lg"
-								dangerouslySetInnerHTML={renderHTMLCustom(fields.leftContent)}
-							/>
+                                className="prose max-w-none overflow-hidden rounded-lg [&_iframe]:aspect-video [&_iframe]:w-full [&_iframe]:rounded-lg"
+                                dangerouslySetInnerHTML={renderHTMLCustom(fields.leftContent)}
+                                data-agility-field="leftContent"
+                                data-agility-html />
 						)}
 
 						{fields.bulletPoints && (
 							<div
-								className="get-a-demo-bullets mt-6 space-y-4"
-								dangerouslySetInnerHTML={renderHTMLCustom(fields.bulletPoints)}
-							/>
+                                className="get-a-demo-bullets mt-6 space-y-4"
+                                dangerouslySetInnerHTML={renderHTMLCustom(fields.bulletPoints)}
+                                data-agility-field="bulletPoints"
+                                data-agility-html />
 						)}
 					</div>
 
@@ -97,32 +103,36 @@ export const GetADemo = async ({ module, languageCode }: UnloadedModuleProps) =>
 					<div className="flex-1 lg:w-1/2">
 						<div className="rounded-lg bg-white p-8 shadow-lg">
 							{fields.formHeading && (
-								<h2 className="text-balance text-2xl font-medium">{fields.formHeading}</h2>
+								<h2
+                                    className="text-balance text-2xl font-medium"
+                                    data-agility-field="formHeading">{fields.formHeading}</h2>
 							)}
 							{fields.formSubHeading && (
-								<p className="mt-2 text-sm text-gray-600">{fields.formSubHeading}</p>
+								<p
+                                    className="mt-2 text-sm text-gray-600"
+                                    data-agility-field="formSubHeading">{fields.formSubHeading}</p>
 							)}
 							<div className={fields.formHeading ? "mt-6" : ""}>
 								<GetADemoClient
-									hubspotForm={fields.hubspotForm}
-									redirectURL={fields.redirectURL}
-									formDefinition={hubspotFormDefinition}
-								/>
+                                    hubspotForm={fields.hubspotForm}
+                                    redirectURL={fields.redirectURL}
+                                    formDefinition={hubspotFormDefinition}
+                                    data-agility-field="hubspotForm" />
 							</div>
 							{fields.formBottomImage?.url && (
 								<div className="mt-6">
 									<img
-										src={fields.formBottomImage.url}
-										alt={fields.formBottomImage.label || ""}
-										className="max-w-full"
-										loading="lazy"
-									/>
+                                        src={fields.formBottomImage.url}
+                                        alt={fields.formBottomImage.label || ""}
+                                        className="max-w-full"
+                                        loading="lazy"
+                                        data-agility-field="formBottomImage" />
 								</div>
 							)}
 						</div>
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/GuideLinks.tsx
+++ b/components/agility-components/GuideLinks.tsx
@@ -46,8 +46,8 @@ export const GuideLinks = async ({ module, languageCode }: UnloadedModuleProps) 
 	const items = lst.items as ContentItem<Link>[]
 
 	return (
-		<GuideWithLinks
-			{...{
+        <GuideWithLinks
+            {...{
 				mainInfo: fields,
 				items: items.map((item) => ({
 					title: item.fields.title,
@@ -55,6 +55,6 @@ export const GuideLinks = async ({ module, languageCode }: UnloadedModuleProps) 
 					uRL: item.fields.uRL
 				}))
 			}}
-		/>
-	)
+            data-agility-component={contentID} />
+    );
 }

--- a/components/agility-components/Heading.tsx
+++ b/components/agility-components/Heading.tsx
@@ -14,12 +14,14 @@ const Heading = async ({ module, languageCode }: UnloadedModuleProps) => {
 	})
 
 	return (
-		<div className="relative px-8">
-			<div className="md:mt-18 mx-auto my-12 max-w-7xl lg:mt-20">
-				<h1 className="font-display text-secondary-500 text-4xl font-black tracking-wide">{fields.title}</h1>
+        <div className="relative px-8" data-agility-component={contentID}>
+            <div className="md:mt-18 mx-auto my-12 max-w-7xl lg:mt-20">
+				<h1
+                    className="font-display text-secondary-500 text-4xl font-black tracking-wide"
+                    data-agility-field="title">{fields.title}</h1>
 			</div>
-		</div>
-	)
+        </div>
+    );
 }
 
 export default Heading

--- a/components/agility-components/HeadlessBenefits/HeadlessBenefits.tsx
+++ b/components/agility-components/HeadlessBenefits/HeadlessBenefits.tsx
@@ -36,26 +36,30 @@ export const HeadlessBenefits = async ({ module, languageCode }: UnloadedModuleP
 	const benefits = (lstBenefits?.items || []) as ContentItem<IHeadlessBenefit>[]
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID} className="relative">
-			{/* Light lavender background wash */}
-			<div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-purple-50/80 via-purple-50/40 to-transparent" />
-			<div className="relative mx-auto grid max-w-7xl items-center gap-8 pb-14 lg:grid-cols-2 lg:gap-16">
+        <Container id={`${contentID}`} data-agility-component={contentID} className="relative">
+            {/* Light lavender background wash */}
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-purple-50/80 via-purple-50/40 to-transparent" />
+            <div className="relative mx-auto grid max-w-7xl items-center gap-8 pb-14 lg:grid-cols-2 lg:gap-16">
 				{/* Left: Illustration */}
 				<div className="flex justify-center">
 					{fields.image && (
 						<>
 							{fields.image.url.endsWith(".svg") ? (
-								<img src={fields.image.url} alt={fields.image.label} className="w-full max-w-md" />
+								<img
+                                    src={fields.image.url}
+                                    alt={fields.image.label}
+                                    className="w-full max-w-md"
+                                    data-agility-field="image" />
 							) : (
 								<AgilityPic
-									image={fields.image}
-									className="w-full max-w-md"
-									fallbackWidth={500}
-									sources={[
+                                    image={fields.image}
+                                    className="w-full max-w-md"
+                                    fallbackWidth={500}
+                                    sources={[
 										{ media: "(min-width: 1200px)", width: 600 },
 										{ media: "(min-width: 768px)", width: 500 },
 									]}
-								/>
+                                    data-agility-field="image" />
 							)}
 						</>
 					)}
@@ -64,7 +68,9 @@ export const HeadlessBenefits = async ({ module, languageCode }: UnloadedModuleP
 				{/* Right: Text + Checklist */}
 				<div>
 					{fields.heading && (
-						<h2 className="text-balance text-3xl font-bold text-primary lg:text-4xl">
+						<h2
+                            className="text-balance text-3xl font-bold text-primary lg:text-4xl"
+                            data-agility-field="heading">
 							{fields.heading}
 						</h2>
 					)}
@@ -83,17 +89,17 @@ export const HeadlessBenefits = async ({ module, languageCode }: UnloadedModuleP
 					{fields.ctaButton && fields.ctaButton.href && (
 						<div className="mt-8">
 							<LinkButton
-								type="primary"
-								size="md"
-								href={fields.ctaButton.href}
-								target={fields.ctaButton.target}
-							>
+                                type="primary"
+                                size="md"
+                                href={fields.ctaButton.href}
+                                target={fields.ctaButton.target}
+                                data-agility-field="ctaButton">
 								{fields.ctaButton.text}
 							</LinkButton>
 						</div>
 					)}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/Hero/Hero.tsx
+++ b/components/agility-components/Hero/Hero.tsx
@@ -25,57 +25,61 @@ export const Hero = async ({ module, languageCode }: UnloadedModuleProps) => {
 	})
 
 	return (
-		<>
-		{fields.mediaType === "image" && fields.image && (
-			<link
-				rel="preload"
-				as="image"
-				imageSrcSet={`${fields.image.url}?format=auto&w=400 400w, ${fields.image.url}?format=auto&w=480 480w, ${fields.image.url}?format=auto&w=800 800w, ${fields.image.url}?format=auto&w=960 960w`}
-				imageSizes="(min-width: 640px) 480px, 400px"
-				fetchPriority="high"
-			/>
-		)}
-		<Container className="text-balance text-center">
-			<div className="mx-auto max-w-7xl">
-				{fields.mediaType === "video" && fields.videoURL && (
-					<div className="mb-10 flex w-full justify-center">
-						<HeroVideo videoURL={fields.videoURL} />
-					</div>
-				)}
+        <>
+            {fields.mediaType === "image" && fields.image && (
+                <link
+                    rel="preload"
+                    as="image"
+                    imageSrcSet={`${fields.image.url}?format=auto&w=400 400w, ${fields.image.url}?format=auto&w=480 480w, ${fields.image.url}?format=auto&w=800 800w, ${fields.image.url}?format=auto&w=960 960w`}
+                    imageSizes="(min-width: 640px) 480px, 400px"
+                    fetchPriority="high"
+                />
+            )}
+            <Container className="text-balance text-center" data-agility-component={contentID}>
+                <div className="mx-auto max-w-7xl">
+                    {fields.mediaType === "video" && fields.videoURL && (
+                        <div className="mb-10 flex w-full justify-center">
+                            <HeroVideo videoURL={fields.videoURL} data-agility-field="videoURL" />
+                        </div>
+                    )}
 
-				{fields.mediaType === "image" && fields.image && (
-					<div className="mb-10 flex w-full justify-center">
-						<AgilityPic
-							image={fields.image}
-							fallbackWidth={400}
-							priority
-							sources={[
-								{ media: "(min-width: 640px) and (min-resolution: 2x)", width: 960 },
-								{ media: "(min-width: 640px)", width: 480 },
-								{ media: "(min-resolution: 2x)", width: 800 },
-							]}
-						/>
-					</div>
-				)}
+                    {fields.mediaType === "image" && fields.image && (
+                        <div className="mb-10 flex w-full justify-center">
+                            <AgilityPic
+                                image={fields.image}
+                                fallbackWidth={400}
+                                priority
+                                sources={[
+                                    { media: "(min-width: 640px) and (min-resolution: 2x)", width: 960 },
+                                    { media: "(min-width: 640px)", width: 480 },
+                                    { media: "(min-resolution: 2x)", width: 800 },
+                                ]}
+                            />
+                        </div>
+                    )}
 
-				{fields.mediaType === "animation" && fields.animation && <HeroAnimation animation={fields.animation} />}
+                    {fields.mediaType === "animation" && fields.animation && <HeroAnimation animation={fields.animation} data-agility-field="animation" />}
 
-				{fields.heading && <h1 className="text-6xl font-black text-highlight-light">{fields.heading}</h1>}
-				{fields.subHeading && <h2 className="mt-2 text-5xl font-bold text-black">{fields.subHeading}</h2>}
-				{fields.content && <p className="mt-3">{fields.content}</p>}
-				{fields.cTA && (
-					<LinkButton
-						type="alternate"
-						size="md"
-						href={fields.cTA.href}
-						target={fields.cTA.target}
-						className="mt-5"
-					>
-						{fields.cTA.text}
-					</LinkButton>
-				)}
-			</div>
-		</Container>
-		</>
-	)
+                    {fields.heading && <h1
+                        className="text-6xl font-black text-highlight-light"
+                        data-agility-field="heading">{fields.heading}</h1>}
+                    {fields.subHeading && <h2
+                        className="mt-2 text-5xl font-bold text-black"
+                        data-agility-field="subHeading">{fields.subHeading}</h2>}
+                    {fields.content && <p className="mt-3" data-agility-field="content">{fields.content}</p>}
+                    {fields.cTA && (
+                        <LinkButton
+                            type="alternate"
+                            size="md"
+                            href={fields.cTA.href}
+                            target={fields.cTA.target}
+                            className="mt-5"
+                            data-agility-field="cTA">
+                            {fields.cTA.text}
+                        </LinkButton>
+                    )}
+                </div>
+            </Container>
+        </>
+    );
 }

--- a/components/agility-components/IntegrationListingModule/NewIntegrationListingModule.tsx
+++ b/components/agility-components/IntegrationListingModule/NewIntegrationListingModule.tsx
@@ -80,10 +80,12 @@ const NewIntegrationListingModule = async ({ module, languageCode, globalData }:
 	})
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<NewIntegrationListingModuleClient {...{ data, allTypes, cTATitle, filterLabel, currentIntegration }} />
-		</Container>
-	)
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <NewIntegrationListingModuleClient
+                {...{ data, allTypes, cTATitle, filterLabel, currentIntegration }}
+                data-agility-field="cTATitle" />
+        </Container>
+    );
 }
 
 export default NewIntegrationListingModule

--- a/components/agility-components/LatestPosts.tsx
+++ b/components/agility-components/LatestPosts.tsx
@@ -40,35 +40,41 @@ export const LatestPosts = async ({ module, languageCode }: UnloadedModuleProps)
 	const posts = lstPosts.items as ContentItem<IPost>[]
 
 	return (
-		<Container>
-			<div className="mx-auto max-w-7xl">
-				<h2 className="text-balance text-center text-4xl font-medium">{fields.title}</h2>
+        <Container>
+            <div className="mx-auto max-w-7xl">
+				<h2
+                    className="text-balance text-center text-4xl font-medium"
+                    data-agility-field="title">{fields.title}</h2>
 				<div className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
 					{posts.map((post, index) => (
 						<Link
-							key={post.contentID}
-							className="group flex flex-col transition-shadow hover:shadow-lg"
-							href={`/blog/${post.fields.uRL}`}
-						>
+                            key={post.contentID}
+                            className="group flex flex-col transition-shadow hover:shadow-lg"
+                            href={`/blog/${post.fields.uRL}`}
+                            data-agility-component={post.contentID}
+                            data-agility-field="uRL">
 							{post.fields.postImage && (
 								<div className="h-48 w-full overflow-clip">
 									<AgilityPic
-										image={post.fields.postImage}
-										fallbackWidth={400}
-										className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-110"
-									/>
+                                        image={post.fields.postImage}
+                                        fallbackWidth={400}
+                                        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-110"
+                                        data-agility-field="postImage" />
 								</div>
 							)}
 							<div className="flex flex-1 flex-col gap-3 border border-t-0 border-background p-5">
-								<h3 className="text-balance text-xl font-semibold">{post.fields.title}</h3>
+								<h3 className="text-balance text-xl font-semibold" data-agility-field="title">{post.fields.title}</h3>
 								<div className="flex-1">
 									<div
-										className="prose prose-slate line-clamp-3 prose-p:leading-snug"
-										dangerouslySetInnerHTML={renderHTMLCustom(post.fields.excerpt)}
-									></div>
+                                        className="prose prose-slate line-clamp-3 prose-p:leading-snug"
+                                        dangerouslySetInnerHTML={renderHTMLCustom(post.fields.excerpt)}
+                                        data-agility-field="excerpt"
+                                        data-agility-html></div>
 								</div>
 								<div className="flex justify-center">
-									<div className="border-2 border-highlight-light px-4 py-2 font-medium text-highlight-light">
+									<div
+                                        className="border-2 border-highlight-light px-4 py-2 font-medium text-highlight-light"
+                                        data-agility-field="readMoreLabel">
 										{fields.readMoreLabel}
 									</div>
 								</div>
@@ -77,11 +83,15 @@ export const LatestPosts = async ({ module, languageCode }: UnloadedModuleProps)
 					))}
 				</div>
 				<div className="mt-10 flex justify-center">
-					<LinkButton type="secondary" size="md" {...fields.primaryButton}>
+					<LinkButton
+                        type="secondary"
+                        size="md"
+                        {...fields.primaryButton}
+                        data-agility-field="primaryButton">
 						{fields.primaryButton.text}
 					</LinkButton>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/LogoListing/LogoListing.server.tsx
+++ b/components/agility-components/LogoListing/LogoListing.server.tsx
@@ -39,20 +39,22 @@ export const LogoListing = async ({ module, languageCode }: UnloadedModuleProps)
 	const lst: ContentItem<LogoItem>[] = shuffle(sampleSize(lstLogos.items, logoCount || 6))
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-7xl">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
 				<div className="flex justify-center">
 					{heading && (
 						<div className="mb-5">
-							<h2 className="mb-3 text-balance text-5xl font-medium leading-10 sm:leading-tight">
+							<h2
+                                className="mb-3 text-balance text-5xl font-medium leading-10 sm:leading-tight"
+                                data-agility-field="heading">
 								{heading}
 							</h2>
 							<ThreeDashLine />
 						</div>
 					)}
 				</div>
-				<LogoListingClient logos={lst.map((l) => l.fields)} />
+				<LogoListingClient logos={lst.map((l) => l.fields)} data-agility-field="logos" />
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/LogoListingModule/LogoListingModule.server.tsx
+++ b/components/agility-components/LogoListingModule/LogoListingModule.server.tsx
@@ -29,17 +29,19 @@ export const LogoListingModule = async ({ module, languageCode }: UnloadedModule
 	})
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-7xl">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
 				<div className="border-t border-t-background"></div>
 				<div className="flex justify-center">
-					<h3 className="-mt-3 text-balance bg-white px-8 text-center text-sm font-medium uppercase text-highlight-light">
+					<h3
+                        className="-mt-3 text-balance bg-white px-8 text-center text-sm font-medium uppercase text-highlight-light"
+                        data-agility-field="title">
 						{title}
 					</h3>
 				</div>
-				<LogoListingModuleClient logos={shuffle(logos.map((l) => l.fields))} />
+				<LogoListingModuleClient logos={shuffle(logos.map((l) => l.fields))} data-agility-field="logos" />
 				<div className="border-t border-t-background"></div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/NEWAllResources/NEWAllResources.tsx
+++ b/components/agility-components/NEWAllResources/NEWAllResources.tsx
@@ -110,13 +110,14 @@ export const NEWAllResources = async ({ module, languageCode, globalData }: Unlo
 	}
 
 	return (
-		<>
-			<Container >
+        <>
+            <Container >
 				<div className="mx-auto max-w-7xl">
 					<div
-						dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
-						className="prose-xl mx-auto max-w-5xl text-center prose-h2:my-4 prose-h2:text-balance prose-p:text-balance prose-p:leading-snug"
-					></div>
+                        dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
+                        className="prose-xl mx-auto max-w-5xl text-center prose-h2:my-4 prose-h2:text-balance prose-p:text-balance prose-p:leading-snug"
+                        data-agility-field="content"
+                        data-agility-html></div>
 
 					<ResourceListingClient
 						{...{
@@ -140,6 +141,6 @@ export const NEWAllResources = async ({ module, languageCode, globalData }: Unlo
 					/>
 				</div>
 			</Container>
-		</>
-	)
+        </>
+    );
 }

--- a/components/agility-components/NEWDownloadableeBooks.tsx
+++ b/components/agility-components/NEWDownloadableeBooks.tsx
@@ -86,14 +86,15 @@ export const NEWDownloadableeBooks = async ({ module, languageCode }: UnloadedMo
 	const resources = data["resources"] as IMiniResource[]
 
 	return (
-		<div className="py-14">
-			<div className="bg-linear-to-b from-background/40 to-white">
+        <div className="py-14" data-agility-component={contentID}>
+            <div className="bg-linear-to-b from-background/40 to-white">
 				<Container className="mx-auto flex max-w-7xl flex-col">
 					<div className="flex w-full justify-center">
 						<div
-							className="prose w-full max-w-7xl lg:prose-xl prose-h2:mb-4 prose-h2:text-center prose-h2:font-medium prose-h2:leading-tight prose-p:text-center prose-p:leading-tight"
-							dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
-						/>
+                            className="prose w-full max-w-7xl lg:prose-xl prose-h2:mb-4 prose-h2:text-center prose-h2:font-medium prose-h2:leading-tight prose-p:text-center prose-p:leading-tight"
+                            dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
+                            data-agility-field="content"
+                            data-agility-html />
 					</div>
 
 					<div className="mt-8 flex w-full flex-col items-center justify-center gap-6 lg:flex-row lg:items-start">
@@ -135,12 +136,16 @@ export const NEWDownloadableeBooks = async ({ module, languageCode }: UnloadedMo
 						})}
 					</div>
 					<div className="mt-8 flex justify-center">
-						<LinkButton type="secondary" size="md" href={fields.cTAButton?.href}>
+						<LinkButton
+                            type="secondary"
+                            size="md"
+                            href={fields.cTAButton?.href}
+                            data-agility-field="cTAButton">
 							{fields.cTAButton?.text}
 						</LinkButton>
 					</div>
 				</Container>
 			</div>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/NEWFeaturedCaseStudies.tsx
+++ b/components/agility-components/NEWFeaturedCaseStudies.tsx
@@ -66,16 +66,17 @@ export const NEWFeaturedCaseStudies = async ({ module, languageCode }: UnloadedM
 	const caseStudies = data[refName] as ICaseStudyMini[]
 
 	return (
-		<Container
+        <Container
 			id={`agility-component-${module.contentid}`}
 			data-agility-component={module.contentid}
 
 		>
-			<div className="mx-auto max-w-7xl">
+            <div className="mx-auto max-w-7xl">
 				<div
-					dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
-					className="prose-xl mx-auto max-w-5xl text-center prose-h2:my-4 prose-h2:text-balance prose-p:text-balance prose-p:leading-snug"
-				></div>
+                    dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
+                    className="prose-xl mx-auto max-w-5xl text-center prose-h2:my-4 prose-h2:text-balance prose-p:text-balance prose-p:leading-snug"
+                    data-agility-field="content"
+                    data-agility-html></div>
 
 				<div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
 					{caseStudies.map((caseStudy, index) => {
@@ -106,12 +107,16 @@ export const NEWFeaturedCaseStudies = async ({ module, languageCode }: UnloadedM
 				</div>
 				{fields.cTAButton && (
 					<div className="mt-10 text-center">
-						<LinkButton href={fields.cTAButton?.href} type="secondary" size="md">
+						<LinkButton
+                            href={fields.cTAButton?.href}
+                            type="secondary"
+                            size="md"
+                            data-agility-field="cTAButton">
 							{fields.cTAButton?.text}
 						</LinkButton>
 					</div>
 				)}
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/NEWWebinarDownload.tsx
+++ b/components/agility-components/NEWWebinarDownload.tsx
@@ -87,15 +87,18 @@ export const NEWWebinarDownload = async ({ module, languageCode }: UnloadedModul
 	const resources = data["resources"] as IMiniResource[]
 
 	return (
-		<div className="bg-gradient-to-b from-background/40 to-white">
-			<Container className="mx-auto flex max-w-7xl flex-col">
+        <div
+            className="bg-gradient-to-b from-background/40 to-white"
+            data-agility-component={contentID}>
+            <Container className="mx-auto flex max-w-7xl flex-col">
 				<div className="flex w-full justify-center">
 					<div
-						className={clsx(
+                        className={clsx(
 							"prose w-full max-w-7xl lg:prose-xl prose-h2:mb-4 prose-h2:text-balance prose-h2:text-center prose-h2:font-medium prose-h2:leading-tight prose-p:text-center prose-p:leading-tight"
 						)}
-						dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
-					/>
+                        dangerouslySetInnerHTML={renderHTMLCustom(fields.content)}
+                        data-agility-field="content"
+                        data-agility-html />
 				</div>
 
 				<div className="mt-8 flex w-full flex-col items-center justify-center gap-6 lg:flex-row lg:items-start">
@@ -129,11 +132,15 @@ export const NEWWebinarDownload = async ({ module, languageCode }: UnloadedModul
 					})}
 				</div>
 				<div className="mt-8 flex justify-center">
-					<LinkButton type="secondary" size="md" href={fields.cTAButton?.href}>
+					<LinkButton
+                        type="secondary"
+                        size="md"
+                        href={fields.cTAButton?.href}
+                        data-agility-field="cTAButton">
 						{fields.cTAButton?.text}
 					</LinkButton>
 				</div>
 			</Container>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/NewIntegrationModule.tsx
+++ b/components/agility-components/NewIntegrationModule.tsx
@@ -61,8 +61,8 @@ export const NewIntegrationModule = async ({ module, languageCode }: UnloadedMod
 
 	const partners = data[fields.integrationPartners.referencename] as IIntegration[]
 	return (
-		<div className="bg-background">
-			<Container className="mx-auto max-w-6xl">
+        <div className="bg-background" data-agility-component={contentID}>
+            <Container className="mx-auto max-w-6xl">
 				<div
 					className={clsx(
 						"flex flex-col items-center gap-10",
@@ -70,11 +70,20 @@ export const NewIntegrationModule = async ({ module, languageCode }: UnloadedMod
 					)}
 				>
 					<div className="flex w-full flex-col gap-5 lg:w-1/3">
-						<h2 className="text-balance text-4xl">{fields.title}</h2>
-						<div className="prose" dangerouslySetInnerHTML={renderHTMLCustom(fields.description)}></div>
+						<h2 className="text-balance text-4xl" data-agility-field="title">{fields.title}</h2>
+						<div
+                            className="prose"
+                            dangerouslySetInnerHTML={renderHTMLCustom(fields.description)}
+                            data-agility-field="description"
+                            data-agility-html></div>
 						{fields.cTA1Optional && (
 							<div>
-								<LinkButton href={fields.cTA1Optional.href} className="mt-4" type="secondary" size="md">
+								<LinkButton
+                                    href={fields.cTA1Optional.href}
+                                    className="mt-4"
+                                    type="secondary"
+                                    size="md"
+                                    data-agility-field="cTA1Optional">
 									{fields.cTA1Optional.text}
 								</LinkButton>
 							</div>
@@ -97,6 +106,6 @@ export const NewIntegrationModule = async ({ module, languageCode }: UnloadedMod
 					</div>
 				</div>
 			</Container>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/NewPostsFeatured.tsx
+++ b/components/agility-components/NewPostsFeatured.tsx
@@ -68,8 +68,8 @@ export const NewPostsFeatured = async ({ module, languageCode }: UnloadedModuleP
 	const posts = sortByIDs(postsPre, sortIDs)
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-7xl">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
 				<div className="flex w-full flex-col items-center justify-between gap-8 md:flex-row md:flex-wrap md:items-start lg:flex-nowrap">
 					{posts.map((post, index) => (
 						<Link
@@ -97,7 +97,9 @@ export const NewPostsFeatured = async ({ module, languageCode }: UnloadedModuleP
 									></div>
 								)}
 
-								<div className="border-2 border-white p-3 px-4 text-center font-medium text-white">
+								<div
+                                    className="border-2 border-white p-3 px-4 text-center font-medium text-white"
+                                    data-agility-field="readMoreLabel">
 									{fields.readMoreLabel || "Read More"}
 								</div>
 							</div>
@@ -105,6 +107,6 @@ export const NewPostsFeatured = async ({ module, languageCode }: UnloadedModuleP
 					))}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/PartnerDetails/PartnerContentPanel.tsx
+++ b/components/agility-components/PartnerDetails/PartnerContentPanel.tsx
@@ -12,21 +12,28 @@ export const PartnerContentPanel = async ({ languageCode, dynamicPageItem, modul
 	const logo = partner.partnerLogo || partner.logo
 
 	return (
-		<div className="bg-highlight-light text-white">
-			<Container className="">
+        <div
+            className="bg-highlight-light text-white"
+            data-agility-component={dynamicPageItem.contentID}>
+            <Container className="">
 				<div className="mx-auto max-w-7xl">
 					<div className="flex flex-col items-center lg:flex-row">
 						<div className="flex flex-col justify-center gap-4 text-center lg:w-3/5 lg:text-left">
-							<h1 className="text-5xl">{partner.title}</h1>
+							<h1 className="text-5xl" data-agility-field="title">{partner.title}</h1>
 							<div
-								className="prose prose-lg prose-invert"
-								dangerouslySetInnerHTML={renderHTMLCustom(partner.contentPanelCopy || partner.companyDescription)}
-							></div>
+                                className="prose prose-lg prose-invert"
+                                dangerouslySetInnerHTML={renderHTMLCustom(partner.contentPanelCopy || partner.companyDescription)}
+                                data-agility-field="contentPanelCopy"
+                                data-agility-html></div>
 						</div>
 						<div className="relative mt-10 flex justify-center lg:mt-0 lg:w-2/5">
 							{logo && (
 								<div className="relative z-[3] h-72 rounded-md bg-white p-6">
-									<AgilityPic image={logo} className="h-full object-contain" fallbackWidth={600} />
+									<AgilityPic
+                                        image={logo}
+                                        className="h-full object-contain"
+                                        fallbackWidth={600}
+                                        data-agility-field="partnerLogo" />
 								</div>
 							)}
 
@@ -39,6 +46,6 @@ export const PartnerContentPanel = async ({ languageCode, dynamicPageItem, modul
 					</div>
 				</div>
 			</Container>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/PartnerDetails/PartnerDetails.tsx
+++ b/components/agility-components/PartnerDetails/PartnerDetails.tsx
@@ -96,8 +96,8 @@ export const PartnerDetails = async ({ languageCode, dynamicPageItem, module }: 
 			: partner.website
 
 	return (
-		<Container className="">
-			<div className="mx-auto max-w-7xl">
+        <Container className="" data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
 				<div className="flex flex-col lg:flex-row">
 					<div className="lg:w-2/3">
 						<h2 className="text-3xl font-medium">{heading}</h2>
@@ -210,16 +210,17 @@ export const PartnerDetails = async ({ languageCode, dynamicPageItem, module }: 
 						{fields.cTAButton && (
 							<div className="mt-14 bg-highlight-light px-6 py-8 text-center">
 								<div
-									className="prose prose-invert"
-									dangerouslySetInnerHTML={renderHTMLCustom(fields.cTAContent)}
-								></div>
+                                    className="prose prose-invert"
+                                    dangerouslySetInnerHTML={renderHTMLCustom(fields.cTAContent)}
+                                    data-agility-field="cTAContent"
+                                    data-agility-html></div>
 								<div className="mt-6">
 									{fields.cTAButton && (
 										<LinkButton
-											type="secondary-inverted"
-											href={fields.cTAButton.href}
-											target={fields.cTAButton.target}
-										>
+                                            type="secondary-inverted"
+                                            href={fields.cTAButton.href}
+                                            target={fields.cTAButton.target}
+                                            data-agility-field="cTAButton">
 											{fields.cTAButton.text}
 										</LinkButton>
 									)}
@@ -251,7 +252,9 @@ export const PartnerDetails = async ({ languageCode, dynamicPageItem, module }: 
 
 				{otherPartnersFiltered.length > 0 && (
 					<div>
-						<h2 className="mt-14 text-center text-3xl font-medium">{fields.titleMorePartners}</h2>
+						<h2
+                            className="mt-14 text-center text-3xl font-medium"
+                            data-agility-field="titleMorePartners">{fields.titleMorePartners}</h2>
 						<div className="mt-10 flex flex-col items-center justify-center gap-3 lg:flex-row">
 							{otherPartnersFiltered.map((item) => (
 								<div key={item.contentID} className="flex flex-col md:w-[400px] lg:w-[300px] xl:w-[480px]">
@@ -272,16 +275,16 @@ export const PartnerDetails = async ({ languageCode, dynamicPageItem, module }: 
 				<div className="mt-10 text-center">
 					{fields.exploreAllPartners && (
 						<LinkButton
-							size="md"
-							type="secondary"
-							href={fields.exploreAllPartners.href}
-							target={fields.exploreAllPartners.target}
-						>
+                            size="md"
+                            type="secondary"
+                            href={fields.exploreAllPartners.href}
+                            target={fields.exploreAllPartners.target}
+                            data-agility-field="exploreAllPartners">
 							{fields.exploreAllPartners.text}
 						</LinkButton>
 					)}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/PartnerListing/PartnerListing.tsx
+++ b/components/agility-components/PartnerListing/PartnerListing.tsx
@@ -78,8 +78,8 @@ export const PartnerListing = async ({ module, languageCode, globalData }: Unloa
 	}
 
 	return (
-		<PartnerListingClient
-			{...{
+        <PartnerListingClient
+            {...{
 				pageSize,
 				partnerType: fields.partners.referencename.includes("implementation")
 					? "implementation"
@@ -89,6 +89,6 @@ export const PartnerListing = async ({ module, languageCode, globalData }: Unloa
 				firstPage,
 				getNextItems
 			}}
-		/>
-	)
+            data-agility-component={contentID} />
+    );
 }

--- a/components/agility-components/PartnerLogoListing/PartnerLogoListing.server.tsx
+++ b/components/agility-components/PartnerLogoListing/PartnerLogoListing.server.tsx
@@ -32,12 +32,14 @@ export const PartnerLogoListing = async ({ module, languageCode }: UnloadedModul
 	const lstPartners = shuffle(sampleSize(partners, logoCount || 6))
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-7xl">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
 				<div className="flex justify-center">
 					{heading && (
 						<div className="mb-5">
-							<h2 className="mb-3 text-balance text-5xl font-medium leading-10 sm:leading-tight">
+							<h2
+                                className="mb-3 text-balance text-5xl font-medium leading-10 sm:leading-tight"
+                                data-agility-field="heading">
 								{heading}
 							</h2>
 							<ThreeDashLine />
@@ -46,6 +48,6 @@ export const PartnerLogoListing = async ({ module, languageCode }: UnloadedModul
 				</div>
 				<PartnerLogoListingClient logos={lstPartners.map((l) => l.fields)} />
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/Podcast/PodcastContentPanel.tsx
+++ b/components/agility-components/Podcast/PodcastContentPanel.tsx
@@ -20,8 +20,8 @@ export const PodcastContentPanel = async ({ module, languageCode }: UnloadedModu
 	})
 
 	return (
-		<Container >
-			<div className="mx-auto max-w-7xl">
+        <Container data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
 				<div
 					className={clsx(
 						"flex flex-col items-center gap-8 lg:flex-row lg:items-start",
@@ -29,17 +29,27 @@ export const PodcastContentPanel = async ({ module, languageCode }: UnloadedModu
 					)}
 				>
 					<div>
-						{fields.image && <AgilityPic image={fields.image} fallbackWidth={640} className="" />}
+						{fields.image && <AgilityPic
+                            image={fields.image}
+                            fallbackWidth={640}
+                            className=""
+                            data-agility-field="image" />}
 						{fields.podcastEmbedCode && (
-							<div dangerouslySetInnerHTML={{ __html: fields.podcastEmbedCode }}></div>
+							<div
+                                dangerouslySetInnerHTML={{ __html: fields.podcastEmbedCode }}
+                                data-agility-field="podcastEmbedCode"></div>
 						)}
 					</div>
 					<div>
-						<h1 className="text-balance text-4xl font-medium">{fields.title}</h1>
-						<div className="prose mt-5" dangerouslySetInnerHTML={renderHTMLCustom(fields.textblob)} />
+						<h1 className="text-balance text-4xl font-medium" data-agility-field="title">{fields.title}</h1>
+						<div
+                            className="prose mt-5"
+                            dangerouslySetInnerHTML={renderHTMLCustom(fields.textblob)}
+                            data-agility-field="textblob"
+                            data-agility-html />
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/Podcast/PodcastListing.tsx
+++ b/components/agility-components/Podcast/PodcastListing.tsx
@@ -26,34 +26,35 @@ export const PodcastListing = async ({ module, languageCode }: UnloadedModulePro
 	const pods = lstPods.items as ContentItem<IPodCast>[]
 
 	return (
-		<Container >
-			<div className="mx-auto max-w-7xl">
+        <Container data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
 					{pods.map((pod) => {
 						return (
-							<Link
-								key={pod.contentID}
-								href={`/resources/agileliving/${pod.fields.uRL}`}
-								className="group flex flex-col transition-shadow duration-200 hover:shadow-lg"
-							>
-								<div className="h-52 overflow-clip">
+                            <Link
+                                key={pod.contentID}
+                                href={`/resources/agileliving/${pod.fields.uRL}`}
+                                className="group flex flex-col transition-shadow duration-200 hover:shadow-lg"
+                                data-agility-component={pod.contentID}
+                                data-agility-field="uRL">
+                                <div className="h-52 overflow-clip">
 									{(pod.fields.listingImage || pod.fields.mainImage) && (
 										<AgilityPic
-											image={pod.fields.listingImage || pod.fields.mainImage}
-											fallbackWidth={400}
-											className="w-full object-contain transition-transform duration-300 group-hover:scale-110"
-										/>
+                                            image={pod.fields.listingImage || pod.fields.mainImage}
+                                            fallbackWidth={400}
+                                            className="w-full object-contain transition-transform duration-300 group-hover:scale-110"
+                                            data-agility-field="listingImage" />
 									)}
 								</div>
-								<div className="flex-1 border border-t-0 border-background p-5">
-									<p className="text-sm text-slate-500">EPISODE #{pod.fields.episodeNumber}</p>
-									<h3 className="mt-3 text-lg font-medium">{pod.fields.title}</h3>
+                                <div className="flex-1 border border-t-0 border-background p-5">
+									<p className="text-sm text-slate-500" data-agility-field="episodeNumber">EPISODE #{pod.fields.episodeNumber}</p>
+									<h3 className="mt-3 text-lg font-medium" data-agility-field="title">{pod.fields.title}</h3>
 								</div>
-							</Link>
-						)
+                            </Link>
+                        );
 					})}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/Pricing/PricingPackagesModule.tsx
+++ b/components/agility-components/Pricing/PricingPackagesModule.tsx
@@ -183,11 +183,9 @@ export const PricingPackagesModule = async ({ module, languageCode }: UnloadedMo
 	const topSectionIDStr = `${contentID}-top`
 
 	return (
-		<>
-
-
-			<PricingPackagesModuleClient
-				{...{
+        <>
+            <PricingPackagesModuleClient
+                {...{
 					headerIDstr,
 					topSectionIDStr,
 					comparePackagesTitle: fields.comparePackagesTitle,
@@ -196,7 +194,8 @@ export const PricingPackagesModule = async ({ module, languageCode }: UnloadedMo
 					pricingPackages: data.pricingpackages,
 					featuresListing: data.packagefeaturevalues
 				}}
-			/>
-		</>
-	)
+                data-agility-component={contentID}
+                data-agility-field="comparePackagesTitle" />
+        </>
+    );
 }

--- a/components/agility-components/ResourceDetails/ResourceDetails.tsx
+++ b/components/agility-components/ResourceDetails/ResourceDetails.tsx
@@ -44,8 +44,8 @@ export const ResourceDetails = async ({ module, languageCode, dynamicPageItem }:
 		? fields.redirectURL.href.replace("##URL##", encodeURIComponent(res.uRL))
 		: undefined
 	return (
-		<Container >
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container >
+            <div className="mx-auto max-w-7xl pb-14">
 				<div className="gap-8 lg:flex lg:flex-row">
 					<div className="flex-1">
 						<time className="text-sm text-gray-500">{dateStr}</time>
@@ -95,7 +95,10 @@ export const ResourceDetails = async ({ module, languageCode, dynamicPageItem }:
 
 						{(res.hubspotForm || fields.hubspotForm) && res.gated === "true" && (
 							<div className="mt-6">
-								<DownloadForm hubspotForm={res.hubspotForm || fields.hubspotForm!} redirectURL={downloadRedirectUrl} />
+								<DownloadForm
+                                    hubspotForm={res.hubspotForm || fields.hubspotForm!}
+                                    redirectURL={downloadRedirectUrl}
+                                    data-agility-field="redirectURL" />
 							</div>
 						)}
 
@@ -166,6 +169,6 @@ export const ResourceDetails = async ({ module, languageCode, dynamicPageItem }:
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/ReviewRotator/ReviewRotator.tsx
+++ b/components/agility-components/ReviewRotator/ReviewRotator.tsx
@@ -32,17 +32,17 @@ export const ReviewRotator = async ({ module, languageCode }: UnloadedModuleProp
 	})
 
 	return (
-		<Container >
-			<div className="mx-auto max-w-7xl">
-				{fields.title && <h2 className="text-center text-4xl font-medium">{fields.title}</h2>}
+        <Container >
+            <div className="mx-auto max-w-7xl">
+				{fields.title && <h2 className="text-center text-4xl font-medium" data-agility-field="title">{fields.title}</h2>}
 				<ReviewRotatorClient
-					{...{
+                    {...{
 						reviews: lstReviews.items,
 						collapseReviewText: fields.collapseReviewText,
 						expandReviewText: fields.expandReviewText
 					}}
-				/>
+                    data-agility-field="collapseReviewText" />
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/RightORLeftContentModule/RightORLeftContentModule.tsx
+++ b/components/agility-components/RightORLeftContentModule/RightORLeftContentModule.tsx
@@ -70,12 +70,12 @@ const RightORLeftContentModule = async ({ module, languageCode }: UnloadedModule
 	const hasImage = graphic && !hasVideo
 
 	return (
-		<Container
+        <Container
 			id={`${contentID}`}
 			data-agility-component={contentID}
 			className={clsx(darkMode ? "bg-gray-900 text-white" : "")}
 		>
-			<div
+            <div
 				className={clsx(
 					"mx-auto flex max-w-7xl flex-col items-center gap-6",
 					textSide === "left" ? "md:flex-row-reverse" : "md:flex-row",
@@ -91,51 +91,65 @@ const RightORLeftContentModule = async ({ module, languageCode }: UnloadedModule
 							{graphic.url.endsWith(".svg") ? (
 								//don't need to use AgilityPic for SVGs
 								// eslint-disable-next-line @next/next/no-img-element
-								<img src={graphic.url} alt={graphic.label} className="w-full" />
+								(<img
+                                    src={graphic.url}
+                                    alt={graphic.label}
+                                    className="w-full"
+                                    data-agility-field="graphic" />)
 							) : (
 								<AgilityPic
-									image={graphic}
-									className="w-full"
-									fallbackWidth={640}
-									sources={[
+                                    image={graphic}
+                                    className="w-full"
+                                    fallbackWidth={640}
+                                    sources={[
 										//screen at least than 640, it's 1/2 of the screen, so the same size as the prev breakpoint
 										{ media: "(min-width: 1200px)", width: 800 }
 									]}
-								/>
+                                    data-agility-field="graphic" />
 							)}
 						</>
 					)}
 				</div>
 				<div className="flex-1">
-					{breadcrumb && <div className={clsx("mb-2 text-sm font-semibold", darkMode ? "text-gray-400" : "text-gray-600")}>{breadcrumb}</div>}
-					<HeadingTag className="text-balance text-5xl font-medium leading-[1.15]">{title}</HeadingTag>
+					{breadcrumb && <div
+                        className={clsx("mb-2 text-sm font-semibold", darkMode ? "text-gray-400" : "text-gray-600")}
+                        data-agility-field="breadcrumb">{breadcrumb}</div>}
+					<HeadingTag
+                        className="text-balance text-5xl font-medium leading-[1.15]"
+                        data-agility-field="title">{title}</HeadingTag>
 					{description && (
 						<div
-							className={clsx("prose mt-5 max-w-none", darkMode ? "prose-invert" : "")}
-							dangerouslySetInnerHTML={renderHTMLCustom(description)}
-						></div>
+                            className={clsx("prose mt-5 max-w-none", darkMode ? "prose-invert" : "")}
+                            dangerouslySetInnerHTML={renderHTMLCustom(description)}
+                            data-agility-field="description"
+                            data-agility-html></div>
 					)}
 					<div className="mt-7 flex gap-2">
 						{cTA1Optional && (
-							<LinkButton type={darkMode ? "primary" : "primary"} href={cTA1Optional.href} target={cTA1Optional.target} size="md">
+							<LinkButton
+                                type={darkMode ? "primary" : "primary"}
+                                href={cTA1Optional.href}
+                                target={cTA1Optional.target}
+                                size="md"
+                                data-agility-field="cTA1Optional">
 								{cTA1Optional.text}
 							</LinkButton>
 						)}
 						{cTA2Optional && cTA2Optional.href !== "" && (
 							<LinkButton
-								type={darkMode ? "primary" : "primary"}
-								href={cTA2Optional.href}
-								target={cTA2Optional.target}
-								size="md"
-							>
+                                type={darkMode ? "primary" : "primary"}
+                                href={cTA2Optional.href}
+                                target={cTA2Optional.target}
+                                size="md"
+                                data-agility-field="cTA2Optional">
 								{cTA2Optional.text}
 							</LinkButton>
 						)}
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }
 
 export default RightORLeftContentModule

--- a/components/agility-components/RightOrLeftCaseStudyTestimonial.tsx
+++ b/components/agility-components/RightOrLeftCaseStudyTestimonial.tsx
@@ -42,8 +42,8 @@ export const RightOrLeftCaseStudyTestimonial = async ({ module, languageCode }: 
 	if (!testimonial || !casestudy) return null
 
 	return (
-		<Container >
-			<div className="mx-auto max-w-7xl">
+        <Container >
+            <div className="mx-auto max-w-7xl">
 				<div className={clsx("flex flex-col gap-10 lg:items-center",
 					fields.textSide == "right" ? "lg:flex-row" : "lg:flex-row-reverse")}>
 					<div className="flex-1 space-y-5">
@@ -52,14 +52,22 @@ export const RightOrLeftCaseStudyTestimonial = async ({ module, languageCode }: 
 						</div>
 						<h2 className="text-3xl">{casestudy.fields.title}</h2>
 						<div className="text-lg">{casestudy.fields.contentPanelCopy}</div>
-						<LinkButton href={`/resources/case-studies/${casestudy.fields.uRL}`} type="alternate" size="md">
+						<LinkButton
+                            href={`/resources/case-studies/${casestudy.fields.uRL}`}
+                            type="alternate"
+                            size="md"
+                            data-agility-field="cTA">
 							{fields.cTA}
 							<IconChevronRight size={20} />
 						</LinkButton>
 					</div>
 					<div className="flex-1">
 						<div className="pr-14">
-							<AgilityPic image={fields.image} className="w-full" fallbackWidth={640} />
+							<AgilityPic
+                                image={fields.image}
+                                className="w-full"
+                                fallbackWidth={640}
+                                data-agility-field="image" />
 						</div>
 						<div className="relative -mt-28 ml-[20%] w-4/5 rounded bg-white p-4 pl-10 shadow-md">
 							<div className="text-lg">{testimonial.fields.excerpt}</div>
@@ -72,6 +80,6 @@ export const RightOrLeftCaseStudyTestimonial = async ({ module, languageCode }: 
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/RightOrLeftSteps.tsx
+++ b/components/agility-components/RightOrLeftSteps.tsx
@@ -29,14 +29,18 @@ const RightOrLeftSteps = async ({ module, languageCode }: UnloadedModuleProps) =
 	const darkMode = fields.darkMode === "true"
 
 	return (
-		<Container
+        <Container
 			id={`${contentID}`}
 			data-agility-component={contentID}
 			className={clsx(darkMode ? "bg-gray-900 text-white" : "")}
 		>
-			<div className="mx-auto max-w-5xl pb-14">
-				{title && <h2 className="text-balance text-center text-4xl leading-10 sm:leading-tight">{title}</h2>}
-				{subTitle && <h4 className="mb-10 mt-4 text-balance text-center">{subTitle}</h4>}
+            <div className="mx-auto max-w-5xl pb-14">
+				{title && <h2
+                    className="text-balance text-center text-4xl leading-10 sm:leading-tight"
+                    data-agility-field="title">{title}</h2>}
+				{subTitle && <h4
+                    className="mb-10 mt-4 text-balance text-center"
+                    data-agility-field="subTitle">{subTitle}</h4>}
 
 				<div
 					className={clsx(
@@ -49,20 +53,20 @@ const RightOrLeftSteps = async ({ module, languageCode }: UnloadedModuleProps) =
 						{image.url.endsWith(".svg") ? (
 							//don't need to use AgilityPic for SVGs
 							// eslint-disable-next-line @next/next/no-img-element
-							<img
-								src={image.url}
-								alt={image.label}
-								className="w-full"
-								width={image.width || 600}
-								height={image.height || 400}
-							/>
+							(<img
+                                src={image.url}
+                                alt={image.label}
+                                className="w-full"
+                                width={image.width || 600}
+                                height={image.height || 400}
+                                data-agility-field="image" />)
 						) : (
 							<AgilityPic
-								image={image}
-								className="w-full"
-								fallbackWidth={400}
-								sources={[{ media: "(min-width: 1200px)", width: 600 }]}
-							/>
+                                image={image}
+                                className="w-full"
+                                fallbackWidth={400}
+                                sources={[{ media: "(min-width: 1200px)", width: 600 }]}
+                                data-agility-field="image" />
 						)}
 					</div>
 
@@ -70,23 +74,26 @@ const RightOrLeftSteps = async ({ module, languageCode }: UnloadedModuleProps) =
 						{step && (
 							<div>
 								<span
-									className={clsx(
+                                    className={clsx(
 										"rounded-full px-4 py-1 text-sm font-medium uppercase",
 										darkMode ? "bg-secondary text-black" : "bg-highlight-light text-white"
 									)}
-								>
+                                    data-agility-field="step">
 									{step}
 								</span>
 							</div>
 						)}
-						{heading && <h3 className="mt-5 text-2xl font-medium">{heading}</h3>}
+						{heading && <h3 className="mt-5 text-2xl font-medium" data-agility-field="heading">{heading}</h3>}
 
-						{description && <div dangerouslySetInnerHTML={renderHTMLCustom(description)} />}
+						{description && <div
+                            dangerouslySetInnerHTML={renderHTMLCustom(description)}
+                            data-agility-field="description"
+                            data-agility-html />}
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }
 
 export default RightOrLeftSteps

--- a/components/agility-components/ScheduleADemo/ScheduleADemo.tsx
+++ b/components/agility-components/ScheduleADemo/ScheduleADemo.tsx
@@ -16,28 +16,31 @@ export const ScheduleADemo = async ({ module, languageCode }: UnloadedModuleProp
 	})
 
 	return (
-		<div
-			id="scheduler-page"
-			className="bg-background/40"
-			style={{
+        <div
+            id="scheduler-page"
+            className="bg-background/40"
+            style={{
 				backgroundImage: "url(/images/icon-agility.svg)",
 				backgroundRepeat: "no-repeat",
 				backgroundPosition: "left bottom"
 			}}
-		>
-			<Container className="mx-auto my-12 flex max-w-7xl">
+            data-agility-component={contentID}>
+            <Container className="mx-auto my-12 flex max-w-7xl">
 				<div className="my-8 flex w-full flex-col gap-5 lg:flex-row">
 					<div className="lg:w-2/5">
 						<div
-							className="prose lg:prose-lg"
-							dangerouslySetInnerHTML={renderHTMLCustom(fields.leftPanelContent)}
-						></div>
+                            className="prose lg:prose-lg"
+                            dangerouslySetInnerHTML={renderHTMLCustom(fields.leftPanelContent)}
+                            data-agility-field="leftPanelContent"
+                            data-agility-html></div>
 					</div>
 					<div className="lg:w-3/5">
-						<ScheduleADemoClient schedulerIFrameURL={fields.schedulerIFrameURL} />
+						<ScheduleADemoClient
+                            schedulerIFrameURL={fields.schedulerIFrameURL}
+                            data-agility-field="schedulerIFrameURL" />
 					</div>
 				</div>
 			</Container>
-		</div>
-	)
+        </div>
+    );
 }

--- a/components/agility-components/SingleTestimonialPanel.tsx
+++ b/components/agility-components/SingleTestimonialPanel.tsx
@@ -26,8 +26,8 @@ const SingleTestimonialPanel = async ({ module, languageCode }: UnloadedModulePr
 	const testimonial = shuffle(testimonials)[0]
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<section className="isolate overflow-hidden bg-white px-6 lg:px-8">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <section className="isolate overflow-hidden bg-white px-6 lg:px-8">
 				<div className="relative mx-auto max-w-2xl py-24 sm:py-32 lg:max-w-4xl">
 					<div className="absolute left-1/2 top-0 -z-10 h-[50rem] w-[90rem] -translate-x-1/2 bg-[radial-gradient(50%_100%_at_top,theme(colors.purple.100),white)] opacity-20 lg:left-36" />
 					<div className="absolute inset-y-0 right-1/2 -z-10 mr-12 w-[150vw] origin-bottom-left skew-x-[-30deg] bg-white shadow-xl shadow-purple-600/10 ring-1 ring-purple-50 sm:mr-20 md:mr-0 lg:right-full lg:-mr-36 lg:origin-center" />
@@ -89,20 +89,20 @@ const SingleTestimonialPanel = async ({ module, languageCode }: UnloadedModulePr
 					{cTAButton && (
 						<div className="flex justify-center">
 							<LinkButton
-								href={cTAButton.href}
-								target={cTAButton.target}
-								className="mt-8"
-								size="md"
-								type="alternate"
-							>
+                                href={cTAButton.href}
+                                target={cTAButton.target}
+                                className="mt-8"
+                                size="md"
+                                type="alternate"
+                                data-agility-field="cTAButton">
 								{cTAButton.text}
 							</LinkButton>
 						</div>
 					)}
 				</div>
 			</section>
-		</Container>
-	)
+        </Container>
+    );
 }
 
 export default SingleTestimonialPanel

--- a/components/agility-components/SplitHero/SplitHero.tsx
+++ b/components/agility-components/SplitHero/SplitHero.tsx
@@ -37,107 +37,112 @@ export const SplitHero = async ({ module, languageCode }: UnloadedModuleProps) =
 	].filter((w): w is string => !!w && w.trim().length > 0)
 
 	return (
-		<>
-		{/* Hoist preload hints so the hero image starts fetching before the parser
-		    reaches the <picture> element. Each media query mirrors the matching
-		    <picture> source below, so the preloaded file is the one actually used. */}
-		{fields.image && (
-			<>
-				<link
-					rel="preload"
-					as="image"
-					href={preloadUrl(400)}
-					media="(max-width: 639px)"
-					fetchPriority="high"
-				/>
-				<link
-					rel="preload"
-					as="image"
-					href={preloadUrl(500)}
-					media="(min-width: 640px) and (max-width: 767px)"
-					fetchPriority="high"
-				/>
-				<link
-					rel="preload"
-					as="image"
-					href={preloadUrl(600)}
-					media="(min-width: 768px) and (max-width: 1199px)"
-					fetchPriority="high"
-				/>
-				<link
-					rel="preload"
-					as="image"
-					href={preloadUrl(700)}
-					media="(min-width: 1200px)"
-					fetchPriority="high"
-				/>
-			</>
-		)}
-		<Container id={`${contentID}`} data-agility-component={contentID} className="relative overflow-hidden">
-			{/* Subtle purple gradient wash */}
-			<div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-purple-50 via-white to-purple-50/50" />
-			<div className="relative mx-auto flex max-w-7xl flex-col items-center gap-16 pb-14 lg:flex-row">
-				{/* Left: Text Content */}
-				<div className="space-y-8 lg:w-1/2">
-					{cyclingWords.length > 0 && fields.heading ? (
-						<CyclingHeading words={cyclingWords} heading={fields.heading} />
-					) : (
-						fields.heading && (
-							<h1 className="text-balance text-5xl font-extrabold leading-tight tracking-tight text-primary lg:text-7xl">
-								{fields.heading}
-							</h1>
-						)
-					)}
-					{fields.description && (
-						<p className="text-lg text-gray-600 lg:text-xl">{fields.description}</p>
-					)}
-					{(fields.primaryCTA || fields.secondaryCTA) && (
-						<div className="flex flex-col gap-4 sm:flex-row">
-							{fields.primaryCTA && fields.primaryCTA.href && (
-								<LinkButton
-									type="primary"
-									size="lg"
-									href={fields.primaryCTA.href}
-									target={fields.primaryCTA.target}
-									className="rounded-full shadow-xl"
-								>
-									{fields.primaryCTA.text}
-								</LinkButton>
-							)}
-							{fields.secondaryCTA && fields.secondaryCTA.href && (
-								<LinkButton
-									type="secondary"
-									size="lg"
-									href={fields.secondaryCTA.href}
-									target={fields.secondaryCTA.target}
-									className="rounded-full"
-								>
-									{fields.secondaryCTA.text}
-								</LinkButton>
-							)}
-						</div>
-					)}
-				</div>
+        <>
+            {/* Hoist preload hints so the hero image starts fetching before the parser
+                reaches the <picture> element. Each media query mirrors the matching
+                <picture> source below, so the preloaded file is the one actually used. */}
+            {fields.image && (
+                <>
+                    <link
+                        rel="preload"
+                        as="image"
+                        href={preloadUrl(400)}
+                        media="(max-width: 639px)"
+                        fetchPriority="high"
+                    />
+                    <link
+                        rel="preload"
+                        as="image"
+                        href={preloadUrl(500)}
+                        media="(min-width: 640px) and (max-width: 767px)"
+                        fetchPriority="high"
+                    />
+                    <link
+                        rel="preload"
+                        as="image"
+                        href={preloadUrl(600)}
+                        media="(min-width: 768px) and (max-width: 1199px)"
+                        fetchPriority="high"
+                    />
+                    <link
+                        rel="preload"
+                        as="image"
+                        href={preloadUrl(700)}
+                        media="(min-width: 1200px)"
+                        fetchPriority="high"
+                    />
+                </>
+            )}
+            <Container id={`${contentID}`} data-agility-component={contentID} className="relative overflow-hidden">
+                {/* Subtle purple gradient wash */}
+                <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-purple-50 via-white to-purple-50/50" />
+                <div className="relative mx-auto flex max-w-7xl flex-col items-center gap-16 pb-14 lg:flex-row">
+                    {/* Left: Text Content */}
+                    <div className="space-y-8 lg:w-1/2">
+                        {cyclingWords.length > 0 && fields.heading ? (
+                            <CyclingHeading
+                                words={cyclingWords}
+                                heading={fields.heading}
+                                data-agility-field="highlightedHeading" />
+                        ) : (
+                            fields.heading && (
+                                <h1 className="text-balance text-5xl font-extrabold leading-tight tracking-tight text-primary lg:text-7xl">
+                                    {fields.heading}
+                                </h1>
+                            )
+                        )}
+                        {fields.description && (
+                            <p
+                                className="text-lg text-gray-600 lg:text-xl"
+                                data-agility-field="description">{fields.description}</p>
+                        )}
+                        {(fields.primaryCTA || fields.secondaryCTA) && (
+                            <div className="flex flex-col gap-4 sm:flex-row">
+                                {fields.primaryCTA && fields.primaryCTA.href && (
+                                    <LinkButton
+                                        type="primary"
+                                        size="lg"
+                                        href={fields.primaryCTA.href}
+                                        target={fields.primaryCTA.target}
+                                        className="rounded-full shadow-xl"
+                                        data-agility-field="primaryCTA">
+                                        {fields.primaryCTA.text}
+                                    </LinkButton>
+                                )}
+                                {fields.secondaryCTA && fields.secondaryCTA.href && (
+                                    <LinkButton
+                                        type="secondary"
+                                        size="lg"
+                                        href={fields.secondaryCTA.href}
+                                        target={fields.secondaryCTA.target}
+                                        className="rounded-full"
+                                        data-agility-field="secondaryCTA">
+                                        {fields.secondaryCTA.text}
+                                    </LinkButton>
+                                )}
+                            </div>
+                        )}
+                    </div>
 
-				{/* Right: Image */}
-				{fields.image && (
-					<div className="lg:w-1/2">
-						<AgilityPic
-							image={fields.image}
-							className="w-full"
-							fallbackWidth={400}
-							priority
-							sources={[
-								{ media: "(min-width: 1200px)", width: 700 },
-								{ media: "(min-width: 768px)", width: 600 },
-								{ media: "(min-width: 640px)", width: 500 },
-								{ media: "(max-width: 639px)", width: 400 },
-							]}
-						/>
-					</div>
-				)}
-			</div>
-		</Container>
-		</>
-	)
+                    {/* Right: Image */}
+                    {fields.image && (
+                        <div className="lg:w-1/2">
+                            <AgilityPic
+                                image={fields.image}
+                                className="w-full"
+                                fallbackWidth={400}
+                                priority
+                                sources={[
+                                    { media: "(min-width: 1200px)", width: 700 },
+                                    { media: "(min-width: 768px)", width: 600 },
+                                    { media: "(min-width: 640px)", width: 500 },
+                                    { media: "(max-width: 639px)", width: 400 },
+                                ]}
+                                data-agility-field="image" />
+                        </div>
+                    )}
+                </div>
+            </Container>
+        </>
+    );
 }

--- a/components/agility-components/StarterTemplateDetails.tsx
+++ b/components/agility-components/StarterTemplateDetails.tsx
@@ -16,8 +16,8 @@ export const StarterTemplateDetails = async ({ module, languageCode, dynamicPage
 	const frameWorkSvgUrl = framework && framework.fields.logo.url.endsWith(".svg") ? framework.fields.logo.url : null
 
 	return (
-		<Container>
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container data-agility-component={dynamicPageItem.contentID}>
+            <div className="mx-auto max-w-7xl pb-14">
 				<div className="gap-5 lg:flex lg:flex-row">
 					<div className="flex-1">
 						<h1 className="text-balance text-5xl font-medium">{starter.name}</h1>
@@ -95,6 +95,6 @@ export const StarterTemplateDetails = async ({ module, languageCode, dynamicPage
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/StarterTemplateListing.tsx
+++ b/components/agility-components/StarterTemplateListing.tsx
@@ -42,37 +42,48 @@ export const StarterTemplateListing = async ({ module, languageCode }: UnloadedM
 	const templates = lstTemplates.items as ContentItem<IStarterTemplate>[]
 
 	return (
-		<Container >
-			<div className="mx-auto max-w-7xl">
-				<div className="text-center uppercase text-slate-500">{fields.section}</div>
+        <Container data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl">
+				<div
+                    className="text-center uppercase text-slate-500"
+                    data-agility-field="section">{fields.section}</div>
 
-				<h1 className="mt-10 text-balance text-center text-4xl font-medium">{fields.title}</h1>
-				<p className="mt-5 text-center">{fields.description}</p>
+				<h1
+                    className="mt-10 text-balance text-center text-4xl font-medium"
+                    data-agility-field="title">{fields.title}</h1>
+				<p className="mt-5 text-center" data-agility-field="description">{fields.description}</p>
 
 				<div className="mt-10 grid space-y-3 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3">
 					{templates.map((template) => (
 						<Link
-							key={template.contentID}
-							href={`/starters/${template.fields.slug}`}
-							className="group flex flex-col shadow-md transition-shadow duration-200 hover:shadow-lg"
-						>
+                            key={template.contentID}
+                            href={`/starters/${template.fields.slug}`}
+                            className="group flex flex-col shadow-md transition-shadow duration-200 hover:shadow-lg"
+                            data-agility-component={template.contentID}
+                            data-agility-field="slug">
 							<div className="relative h-64 overflow-clip">
 								<AgilityPic
-									image={template.fields.image}
-									fallbackWidth={400}
-									className="w-full object-cover transition-transform duration-300 group-hover:scale-110"
-								/>
+                                    image={template.fields.image}
+                                    fallbackWidth={400}
+                                    className="w-full object-cover transition-transform duration-300 group-hover:scale-110"
+                                    data-agility-field="image" />
 								<div className="absolute inset-0 flex items-center justify-center bg-highlight-light/60 opacity-0 transition-opacity group-hover:opacity-100">
-									<div className="flex items-center gap-2 bg-white p-3 px-4 font-medium text-highlight-light">
+									<div
+                                        className="flex items-center gap-2 bg-white p-3 px-4 font-medium text-highlight-light"
+                                        data-agility-field="viewDetailsLabel">
 										{fields.viewDetailsLabel}
 										<IconChevronRight size={20} />
 									</div>
 								</div>
 							</div>
 							<div className="flex flex-1 flex-col gap-3 p-5">
-								<h4 className="text-lg font-medium text-highlight-light">{template.fields.name}</h4>
-								<p className="flex-1 text-slate-500">{template.fields.description}</p>
-								<div className="flex items-center gap-3 border-t border-t-background pt-5">
+								<h4
+                                    className="text-lg font-medium text-highlight-light"
+                                    data-agility-field="name">{template.fields.name}</h4>
+								<p className="flex-1 text-slate-500" data-agility-field="description">{template.fields.description}</p>
+								<div
+                                    className="flex items-center gap-3 border-t border-t-background pt-5"
+                                    data-agility-field="frameworks">
 									{template.fields.frameworks.map((framework) => {
 										let imgUrl = `${framework.fields.logo.url}?format=auto&h=50`
 										if (framework.fields.logo.url.endsWith(".svg")) {
@@ -93,6 +104,6 @@ export const StarterTemplateListing = async ({ module, languageCode }: UnloadedM
 					))}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/SubmissionForm/SubmissionForm.tsx
+++ b/components/agility-components/SubmissionForm/SubmissionForm.tsx
@@ -21,5 +21,5 @@ export const SubmissionForm = async ({ module, languageCode }: UnloadedModulePro
 		return null
 	}
 
-	return <SubmissionFormClient {...fields} />
+	return <SubmissionFormClient {...fields} data-agility-component={contentID} />;
 }

--- a/components/agility-components/SwitchTestimonials/SwitchTestimonials.tsx
+++ b/components/agility-components/SwitchTestimonials/SwitchTestimonials.tsx
@@ -38,44 +38,52 @@ export const SwitchTestimonials = async ({ module, languageCode }: UnloadedModul
 	const testimonials = lstTestimonials.items as ContentItem<ISwitchTestimonial>[]
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID} className="bg-white">
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID} className="bg-white">
+            <div className="mx-auto max-w-7xl pb-14">
 				<div className="mb-10 text-center">
 					{fields.heading && (
-						<h2 className="text-balance text-3xl font-bold text-primary sm:text-4xl lg:text-5xl">
+						<h2
+                            className="text-balance text-3xl font-bold text-primary sm:text-4xl lg:text-5xl"
+                            data-agility-field="heading">
 							{fields.heading}
 						</h2>
 					)}
 					{fields.description && (
-						<p className="mx-auto mt-3 max-w-2xl text-gray-500">{fields.description}</p>
+						<p
+                            className="mx-auto mt-3 max-w-2xl text-gray-500"
+                            data-agility-field="description">{fields.description}</p>
 					)}
 				</div>
 
 				<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
 					{testimonials.map((t) => (
 						<div
-							key={t.contentID}
-							className="flex flex-col rounded-2xl border border-gray-200/60 bg-[#f8f4ff] p-6 shadow-sm"
-						>
+                            key={t.contentID}
+                            className="flex flex-col rounded-2xl border border-gray-200/60 bg-[#f8f4ff] p-6 shadow-sm"
+                            data-agility-component={t.contentID}>
 							<span
 								className="mb-2 select-none font-serif text-4xl leading-none text-primary/25"
 								aria-hidden="true"
 							>
 								&ldquo;
 							</span>
-							<p className="flex-1 text-sm leading-relaxed text-gray-700">
+							<p
+                                className="flex-1 text-sm leading-relaxed text-gray-700"
+                                data-agility-field="quote">
 								{t.fields.quote}
 							</p>
 							<div className="mt-5 border-t border-gray-200/40 pt-4">
-								<p className="text-sm font-semibold text-primary">
+								<p
+                                    className="text-sm font-semibold text-primary"
+                                    data-agility-field="personTitle">
 									{t.fields.personTitle}
 								</p>
-								<p className="text-sm text-gray-500">{t.fields.company}</p>
+								<p className="text-sm text-gray-500" data-agility-field="company">{t.fields.company}</p>
 							</div>
 						</div>
 					))}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/TestimonialCarousel/TestimonialCarousel.tsx
+++ b/components/agility-components/TestimonialCarousel/TestimonialCarousel.tsx
@@ -54,18 +54,22 @@ export const TestimonialCarousel = async ({ module, languageCode }: UnloadedModu
 	}))
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID} className="bg-purple-100/80">
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID} className="bg-purple-100/80">
+            <div className="mx-auto max-w-7xl pb-14">
 				{/* Section Label + Heading + hint */}
 				<div className="flex items-start justify-between">
 					<div>
 						{fields.sectionLabel && (
-							<p className="text-sm font-semibold uppercase tracking-widest text-purple-400">
+							<p
+                                className="text-sm font-semibold uppercase tracking-widest text-purple-400"
+                                data-agility-field="sectionLabel">
 								{fields.sectionLabel}
 							</p>
 						)}
 						{fields.heading && (
-							<h2 className="mt-3 text-balance text-4xl font-bold text-primary lg:text-5xl">
+							<h2
+                                className="mt-3 text-balance text-4xl font-bold text-primary lg:text-5xl"
+                                data-agility-field="heading">
 								{fields.heading}
 							</h2>
 						)}
@@ -78,14 +82,14 @@ export const TestimonialCarousel = async ({ module, languageCode }: UnloadedModu
 
 				{/* Carousel (client) — lavender theme */}
 				<TestimonialCarouselClient
-					items={items}
-					ctaButton={
+                    items={items}
+                    ctaButton={
 						fields.ctaButton
 							? { href: fields.ctaButton.href, target: fields.ctaButton.target, text: fields.ctaButton.text }
 							: undefined
 					}
-				/>
+                    data-agility-field="ctaButton" />
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/Testimonials/Testimonials.tsx
+++ b/components/agility-components/Testimonials/Testimonials.tsx
@@ -51,12 +51,12 @@ export const Testimonials = async ({ module, languageCode }: UnloadedModuleProps
 	const items: ContentItem<ITestimonial>[] = lst.items
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-5xl text-center">
-				{header && <h2 className="text-balance text-4xl">{header}</h2>}
-				{subHeading && <p className="mt-4 text-balance text-lg">{subHeading}</p>}
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-5xl text-center">
+				{header && <h2 className="text-balance text-4xl" data-agility-field="header">{header}</h2>}
+				{subHeading && <p className="mt-4 text-balance text-lg" data-agility-field="subHeading">{subHeading}</p>}
 			</div>
-			<TestimonialsClient {...{ items: items }} />
-		</Container>
-	)
+            <TestimonialsClient {...{ items: items }} />
+        </Container>
+    );
 }

--- a/components/agility-components/TopFeaturedResources/TopFeaturedResources.tsx
+++ b/components/agility-components/TopFeaturedResources/TopFeaturedResources.tsx
@@ -117,9 +117,9 @@ const TopFeaturedResources = async ({ module, languageCode }: UnloadedModuleProp
 	const title = fields.title || "Featured"
 
 	return (
-		<Container id={`agility-component-${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-7xl text-center">
-				<h2 className="text-balance text-5xl font-medium">{title}</h2>
+        <Container id={`agility-component-${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl text-center">
+				<h2 className="text-balance text-5xl font-medium" data-agility-field="title">{title}</h2>
 				<ThreeDashLine />
 
 				<div className="relative mt-10">
@@ -195,8 +195,8 @@ const TopFeaturedResources = async ({ module, languageCode }: UnloadedModuleProp
 					</div>
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }
 
 export default TopFeaturedResources

--- a/components/agility-components/TriplePanelComparisonModule.tsx
+++ b/components/agility-components/TriplePanelComparisonModule.tsx
@@ -31,35 +31,48 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 	})
 
 	return (
-		<Container
+        <Container
 			id={`${contentID}`}
 			data-agility-component={contentID}
 			className="bg-gradient-to-b from-background/60 to-white/0"
 		>
-			<div className="md:mt-18 mx-auto my-12 max-w-5xl lg:mt-20">
-				<h2 className="text-balance text-center text-5xl font-medium">{fields.title}</h2>
+            <div className="md:mt-18 mx-auto my-12 max-w-5xl lg:mt-20">
+				<h2
+                    className="text-balance text-center text-5xl font-medium"
+                    data-agility-field="title">{fields.title}</h2>
 				{fields.description && (
 					<div
-						className="prose mt-5 max-w-none text-balance text-center"
-						dangerouslySetInnerHTML={renderHTMLCustom(fields.description)}
-					></div>
+                        className="prose mt-5 max-w-none text-balance text-center"
+                        dangerouslySetInnerHTML={renderHTMLCustom(fields.description)}
+                        data-agility-field="description"
+                        data-agility-html></div>
 				)}
 
 				<div className="place-items-centerX mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3">
 					{fields.panel1Graphic && fields.panel1Title && (
 						<div className="flex flex-col gap-4">
 							{fields.panel1Graphic.url.endsWith(".svg") ? (
-								<img src={fields.panel1Graphic.url} alt={fields.panel1Graphic.label} className="w-16" width="64" height="64" />
+								<img
+                                    src={fields.panel1Graphic.url}
+                                    alt={fields.panel1Graphic.label}
+                                    className="w-16"
+                                    width="64"
+                                    height="64"
+                                    data-agility-field="panel1Graphic" />
 							) : (
-								<AgilityPic image={fields.panel1Graphic} className="w-16" fallbackWidth={64} />
+								<AgilityPic
+                                    image={fields.panel1Graphic}
+                                    className="w-16"
+                                    fallbackWidth={64}
+                                    data-agility-field="panel1Graphic" />
 							)}
-							<h3 className="text-lg font-medium">{fields.panel1Title}</h3>
+							<h3 className="text-lg font-medium" data-agility-field="panel1Title">{fields.panel1Title}</h3>
 							{fields.panel1CheckedContent && (
 								<div className="flex items-start gap-3">
 									<div>
 										<IconCheck stroke={2} className="w-6" />
 									</div>
-									<p>{fields.panel1CheckedContent}</p>
+									<p data-agility-field="panel1CheckedContent">{fields.panel1CheckedContent}</p>
 								</div>
 							)}
 							{fields.panel1UncheckedContent && (
@@ -67,7 +80,7 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 									<div>
 										<IconX stroke={2} className="w-6" />
 									</div>
-									<p>{fields.panel1UncheckedContent}</p>
+									<p data-agility-field="panel1UncheckedContent">{fields.panel1UncheckedContent}</p>
 								</div>
 							)}
 						</div>
@@ -75,17 +88,27 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 					{fields.panel2Graphic && fields.panel2Title && (
 						<div className="flex flex-col gap-4">
 							{fields.panel2Graphic.url.endsWith(".svg") ? (
-								<img src={fields.panel2Graphic.url} alt={fields.panel2Graphic.label} className="w-16" width="64" height="64" />
+								<img
+                                    src={fields.panel2Graphic.url}
+                                    alt={fields.panel2Graphic.label}
+                                    className="w-16"
+                                    width="64"
+                                    height="64"
+                                    data-agility-field="panel2Graphic" />
 							) : (
-								<AgilityPic image={fields.panel2Graphic} className="w-16" fallbackWidth={64} />
+								<AgilityPic
+                                    image={fields.panel2Graphic}
+                                    className="w-16"
+                                    fallbackWidth={64}
+                                    data-agility-field="panel2Graphic" />
 							)}
-							<h3 className="text-lg font-medium">{fields.panel2Title}</h3>
+							<h3 className="text-lg font-medium" data-agility-field="panel2Title">{fields.panel2Title}</h3>
 							{fields.panel2CheckedContent && (
 								<div className="flex items-start gap-3">
 									<div>
 										<IconCheck stroke={2} className="w-6" />
 									</div>
-									<p>{fields.panel2CheckedContent}</p>
+									<p data-agility-field="panel2CheckedContent">{fields.panel2CheckedContent}</p>
 								</div>
 							)}
 							{fields.panel2UncheckedContent && (
@@ -93,7 +116,7 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 									<div>
 										<IconX stroke={2} className="w-6" />
 									</div>
-									<p>{fields.panel2UncheckedContent}</p>
+									<p data-agility-field="panel2UncheckedContent">{fields.panel2UncheckedContent}</p>
 								</div>
 							)}
 						</div>
@@ -101,17 +124,27 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 					{fields.panel3Graphic && fields.panel3Title && (
 						<div className="flex flex-col gap-4">
 							{fields.panel3Graphic.url.endsWith(".svg") ? (
-								<img src={fields.panel3Graphic.url} alt={fields.panel3Graphic.label} className="w-16" width="64" height="64" />
+								<img
+                                    src={fields.panel3Graphic.url}
+                                    alt={fields.panel3Graphic.label}
+                                    className="w-16"
+                                    width="64"
+                                    height="64"
+                                    data-agility-field="panel3Graphic" />
 							) : (
-								<AgilityPic image={fields.panel3Graphic} className="w-16" fallbackWidth={64} />
+								<AgilityPic
+                                    image={fields.panel3Graphic}
+                                    className="w-16"
+                                    fallbackWidth={64}
+                                    data-agility-field="panel3Graphic" />
 							)}
-							<h3 className="text-lg font-medium">{fields.panel3Title}</h3>
+							<h3 className="text-lg font-medium" data-agility-field="panel3Title">{fields.panel3Title}</h3>
 							{fields.panel3CheckedContent && (
 								<div className="flex items-start gap-3">
 									<div>
 										<IconCheck stroke={2} className="w-6" />
 									</div>
-									<p>{fields.panel3CheckedContent}</p>
+									<p data-agility-field="panel3CheckedContent">{fields.panel3CheckedContent}</p>
 								</div>
 							)}
 							{fields.panel3UncheckedContent && (
@@ -119,15 +152,15 @@ const TriplePanelComparisonModule = async ({ module, languageCode }: UnloadedMod
 									<div>
 										<IconX stroke={2} className="w-6" />
 									</div>
-									<p>{fields.panel3UncheckedContent}</p>
+									<p data-agility-field="panel3UncheckedContent">{fields.panel3UncheckedContent}</p>
 								</div>
 							)}
 						</div>
 					)}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }
 
 export default TriplePanelComparisonModule

--- a/components/agility-components/TriplePanelModule.tsx
+++ b/components/agility-components/TriplePanelModule.tsx
@@ -43,44 +43,55 @@ export const TriplePanelModule = async ({ module, languageCode }: UnloadedModule
 	const items = lst.items as ContentItem<PanelContentItem>[]
 
 	return (
-		<Container
+        <Container
 			id={`${contentID}`}
 			data-agility-component={contentID}
 			className={clsx(darkMode ? "bg-gray-900 text-white" : "")}
 		>
-			<div className="mx-auto max-w-6xl">
-				<h2 className="text-balance text-center text-5xl">{fields.title}</h2>
+            <div className="mx-auto max-w-6xl">
+				<h2 className="text-balance text-center text-5xl" data-agility-field="title">{fields.title}</h2>
 				{fields.description && (
 					<div
-						className="mt-4 text-center text-lg"
-						dangerouslySetInnerHTML={renderHTMLCustom(fields.description)}
-					></div>
+                        className="mt-4 text-center text-lg"
+                        dangerouslySetInnerHTML={renderHTMLCustom(fields.description)}
+                        data-agility-field="description"
+                        data-agility-html></div>
 				)}
 
 				<div className="mt-12 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
 					{items.map((item, index) => (
-						<div key={index} className={clsx("mb-4 p-6", darkMode ? "bg-slate-700" : "")}>
+						<div
+                            key={index}
+                            className={clsx("mb-4 p-6", darkMode ? "bg-slate-700" : "")}
+                            data-agility-component={item.contentID}>
 							{item.fields.graphic && (
 								<div>
 									{item.fields.graphic.url.endsWith(".svg") ? (
 										<img
-											src={item.fields.graphic.url}
-											alt={item.fields.graphic.label}
-											className="w-16"
-											width={item.fields.graphic.width || 64}
-											height={item.fields.graphic.height || 64}
-										/>
+                                            src={item.fields.graphic.url}
+                                            alt={item.fields.graphic.label}
+                                            className="w-16"
+                                            width={item.fields.graphic.width || 64}
+                                            height={item.fields.graphic.height || 64}
+                                            data-agility-field="graphic" />
 									) : (
-										<AgilityPic image={item.fields.graphic} className="w-16" fallbackWidth={63} />
+										<AgilityPic
+                                            image={item.fields.graphic}
+                                            className="w-16"
+                                            fallbackWidth={63}
+                                            data-agility-field="graphic" />
 									)}
 								</div>
 							)}
-							<h3 className="mt-5 text-balance text-xl font-semibold">{item.fields.title}</h3>
+							<h3
+                                className="mt-5 text-balance text-xl font-semibold"
+                                data-agility-field="title">{item.fields.title}</h3>
 							{item.fields.description && (
 								<div
-									className="mt-4"
-									dangerouslySetInnerHTML={renderHTMLCustom(item.fields.description)}
-								></div>
+                                    className="mt-4"
+                                    dangerouslySetInnerHTML={renderHTMLCustom(item.fields.description)}
+                                    data-agility-field="description"
+                                    data-agility-html></div>
 							)}
 						</div>
 					))}
@@ -89,17 +100,17 @@ export const TriplePanelModule = async ({ module, languageCode }: UnloadedModule
 				{fields.cTAButton && fields.cTAButton?.href !== "" && (
 					<div className="mt-14 text-center">
 						<LinkButton
-							href={fields.cTAButton.href}
-							className="flex items-center gap-1"
-							type={darkMode ? "secondary-inverted" : "alternate"}
-							size="md"
-						>
+                            href={fields.cTAButton.href}
+                            className="flex items-center gap-1"
+                            type={darkMode ? "secondary-inverted" : "alternate"}
+                            size="md"
+                            data-agility-field="cTAButton">
 							<span>{fields.cTAButton.text}</span>
 							<IconChevronRight size={18} stroke={2} />
 						</LinkButton>
 					</div>
 				)}
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/TrustedByLogos/TrustedByLogos.tsx
+++ b/components/agility-components/TrustedByLogos/TrustedByLogos.tsx
@@ -37,17 +37,19 @@ export const TrustedByLogos = async ({ module, languageCode }: UnloadedModulePro
 	const logos = lstLogos.items as ContentItem<ITrustedByLogo>[]
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl pb-14">
 				{fields.heading && (
-					<p className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500">
+					<p
+                        className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500"
+                        data-agility-field="heading">
 						{fields.heading}
 					</p>
 				)}
 				<div className="group mt-8 flex flex-wrap items-center justify-center gap-10 lg:gap-16">
 					{logos.map((item) => {
 						const { logo, name, link } = item.fields
-						if (!logo?.url) return <div key={item.contentID} />
+						if (!logo?.url) return <div key={item.contentID} data-agility-component={item.contentID} />;
 
 						let src = logo.url.endsWith(".svg") ? logo.url : `${logo.url}?format=auto&w=300`
 
@@ -63,16 +65,21 @@ export const TrustedByLogos = async ({ module, languageCode }: UnloadedModulePro
 
 						if (link && link.href) {
 							return (
-								<Link key={item.contentID} href={link.href} target={link.target} title={link.text || name}>
-									{imgEl}
-								</Link>
-							)
+                                <Link
+                                    key={item.contentID}
+                                    href={link.href}
+                                    target={link.target}
+                                    title={link.text || name}
+                                    data-agility-component={item.contentID}>
+                                    {imgEl}
+                                </Link>
+                            );
 						}
 
-						return <div key={item.contentID}>{imgEl}</div>
+						return <div key={item.contentID} data-agility-component={item.contentID}>{imgEl}</div>;
 					})}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/TwoPanelFeatureComparison/TwoPanelFeatureComparison.server.tsx
+++ b/components/agility-components/TwoPanelFeatureComparison/TwoPanelFeatureComparison.server.tsx
@@ -50,13 +50,14 @@ export const TwoPanelFeatureComparison = async ({ module, languageCode }: Unload
 	})
 
 	return (
-		<TwoPanelFeatureComparisonClient
-			{...{
+        <TwoPanelFeatureComparisonClient
+            {...{
 				group1Title: fields.group1Title,
 				group2Title: fields.group2Title,
 				group1Panels: group1Panels.items,
 				group2Panels: group2Panels.items
 			}}
-		/>
-	)
+            data-agility-component={contentID}
+            data-agility-field="group1Title" />
+    );
 }

--- a/components/agility-components/TypeFormModule/TypeFormModule.tsx
+++ b/components/agility-components/TypeFormModule/TypeFormModule.tsx
@@ -23,5 +23,5 @@ export const TypeFormModule = async ({ module, languageCode }: UnloadedModulePro
 		return null
 	}
 
-	return <TypeFormClient {...fields} />
+	return <TypeFormClient {...fields} data-agility-component={contentID} />;
 }

--- a/components/agility-components/ValuePropositionCards/ValuePropositionCards.tsx
+++ b/components/agility-components/ValuePropositionCards/ValuePropositionCards.tsx
@@ -59,16 +59,20 @@ export const ValuePropositionCards = async ({ module, languageCode }: UnloadedMo
 	const cards = lstCards.items as ContentItem<IValuePropositionCard>[]
 
 	return (
-		<Container id={`${contentID}`} data-agility-component={contentID}>
-			<div className="mx-auto max-w-7xl pb-14">
+        <Container id={`${contentID}`} data-agility-component={contentID}>
+            <div className="mx-auto max-w-7xl pb-14">
 				<div className="mx-auto max-w-3xl text-center">
 					{fields.heading && (
-						<h2 className="text-balance text-4xl font-bold text-primary lg:text-5xl">
+						<h2
+                            className="text-balance text-4xl font-bold text-primary lg:text-5xl"
+                            data-agility-field="heading">
 							{fields.heading}
 						</h2>
 					)}
 					{fields.description && (
-						<p className="mt-4 text-balance text-lg text-gray-600">{fields.description}</p>
+						<p
+                            className="mt-4 text-balance text-lg text-gray-600"
+                            data-agility-field="description">{fields.description}</p>
 					)}
 				</div>
 				<div className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
@@ -92,16 +96,20 @@ export const ValuePropositionCards = async ({ module, languageCode }: UnloadedMo
 
 						if (link && link.href) {
 							return (
-								<Link key={item.contentID} href={link.href} target={link.target}>
-									{cardContent}
-								</Link>
-							)
+                                <Link
+                                    key={item.contentID}
+                                    href={link.href}
+                                    target={link.target}
+                                    data-agility-component={item.contentID}>
+                                    {cardContent}
+                                </Link>
+                            );
 						}
 
-						return <div key={item.contentID}>{cardContent}</div>
+						return <div key={item.contentID} data-agility-component={item.contentID}>{cardContent}</div>;
 					})}
 				</div>
 			</div>
-		</Container>
-	)
+        </Container>
+    );
 }

--- a/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
+++ b/components/agility-components/VerticalContentPanel/VerticalContentPanel.server.tsx
@@ -39,34 +39,33 @@ export const VerticalContentPanelServer = async ({ module, languageCode }: Unloa
 	const panels = resPanels.items as ContentItem<VerticalPanel>[]
 
 	return (
-		<div id={`${contentID}`} data-agility-component={contentID} className="px-1 sm:px-8 pt-14">
-			<div className="mx-auto max-w-5xl text-center">
-				{title && <h1 className="text-balance text-4xl">{title}</h1>}
+        <div id={`${contentID}`} data-agility-component={contentID} className="px-1 sm:px-8 pt-14">
+            <div className="mx-auto max-w-5xl text-center">
+				{title && <h1 className="text-balance text-4xl" data-agility-field="title">{title}</h1>}
 				{description && (
 					<div
-						className="vertical-content-panel-desc mt-3 text-xl"
-						dangerouslySetInnerHTML={renderHTMLCustom(description)}
-					/>
+                        className="vertical-content-panel-desc mt-3 text-xl"
+                        dangerouslySetInnerHTML={renderHTMLCustom(description)}
+                        data-agility-field="description"
+                        data-agility-html />
 				)}
 			</div>
-
-			<div className="mx-auto mt-14 max-w-7xl">
+            <div className="mx-auto mt-14 max-w-7xl">
 				{fields.cardStyle === "true" ? (
 					<CardStylePanel
-						contentID={contentID}
-						textSide={textSide}
-						darkMode={fields.darkMode === "true"}
-						panels={panels.map((p) => p.fields)}
-					/>
+                        contentID={contentID}
+                        textSide={textSide}
+                        darkMode={fields.darkMode === "true"}
+                        panels={panels.map((p) => p.fields)}
+                        data-agility-field="textSide" />
 				) : (
 					<VerticleStylePanel
-						contentID={contentID}
-						textSide={textSide}
-
-						panels={panels.map((p) => p.fields)}
-					/>
+                        contentID={contentID}
+                        textSide={textSide}
+                        panels={panels.map((p) => p.fields)}
+                        data-agility-field="textSide" />
 				)}
 			</div>
-		</div>
-	)
+        </div>
+    );
 }


### PR DESCRIPTION
:exclamation::exclamation::exclamation: **Huge PR but I'd like your eyes on it.** :exclamation::exclamation::exclamation:

This PR was a result of using this new tool I generated `agility-decorate`, the repo is here https://github.com/agility/agility-decorate

The tool uses `jscodeshift`, a thin api wrapper around an AST (Abstract Syntax Tree). So instead of messy regex or nondeterministic LLM output, this program navigates the syntax tree and smartly adds field decorators where it can find a place for  it. 

It's a big change but relatively safe, since all it's doing is adding data attributes. 

Please let me know your thoughts!

This is the tool's output :point_down: 

<img width="1611" height="764" alt="image" src="https://github.com/user-attachments/assets/c57a3686-1414-4fff-b208-ee6f3f82cb5b" />
