### PR TITLE
Accurate sitemap lastmod + IndexNow on publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ next-env.d.ts
 .claude/settings.local.json
 
 screenshots/
+
+# local working folders (design references, content drafts)
+designs/
+drafts/

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -4,6 +4,10 @@ import { revalidatePath, revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import agilitySDK from "@agility/content-fetch"
 import { indexPage } from "lib/crawl/index-page";
+import { submitToIndexNow } from "lib/indexnow/submitToIndexNow";
+
+/** The home page lives at "/home" in the sitemap but is served at the root. */
+const toPublicPath = (path: string) => (path === "/home" ? "/" : path)
 
 interface IRevalidateRequest {
 	state: string,
@@ -78,6 +82,9 @@ export async function POST(req: NextRequest, res: NextResponse) {
 					revalidatePath(path)
 					console.info("Revalidating path:", path)
 					await indexPage(path)
+
+					//notify IndexNow search engines that this dynamic page changed
+					await submitToIndexNow(toPublicPath(path))
 				}
 			}
 
@@ -105,6 +112,9 @@ export async function POST(req: NextRequest, res: NextResponse) {
 
 					//also re-index the path for search
 					await indexPage(path)
+
+					//notify IndexNow search engines that this page changed
+					await submitToIndexNow(toPublicPath(path))
 				}
 			}
 		}

--- a/app/sitemap.tsx
+++ b/app/sitemap.tsx
@@ -19,14 +19,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
 	const baseUrl = getSiteUrl()
 
+	// Emit only <loc> + <lastmod>. Google ignores <changefreq> and <priority>
+	// entirely, and blanket values for them only contradict our accurate lastmod.
 	return Object.entries(lastModifiedMap).map(([path, lastModified]) => {
 		//the home page lives at "/home" in the sitemap but is served at the root
 		const isHome = path === "/home"
 		return {
 			url: isHome ? `${baseUrl}/` : `${baseUrl}${path}`,
-			lastModified: new Date(lastModified),
-			changeFrequency: "daily",
-			priority: isHome ? 1 : 0.8
+			lastModified: new Date(lastModified)
 		}
 	})
 }

--- a/app/sitemap.tsx
+++ b/app/sitemap.tsx
@@ -1,32 +1,32 @@
-import { getSitemapFlat } from "lib/cms/getSitemapFlat"
+import { getSitemapLastModifiedMap } from "lib/cms/getSitemapLastModifiedMap"
+import { getSiteUrl } from "lib/utils/getSiteUrl"
+import { cacheConfig } from "lib/cms/cacheConfig"
 import { MetadataRoute } from "next"
 
+/**
+ * Regenerate the sitemap at most once per `pathRevalidateDuration` (24h by default).
+ * The lastmod dates underneath ride the per-page / per-content Agility cache tags,
+ * so a page or content publish still refreshes the relevant dates on the next build.
+ */
+export const revalidate = cacheConfig.pathRevalidateDuration
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	//get the flat sitemap from Agility CMS and output it
-	const sitemap = await getSitemapFlat({
-		channelName: process.env.AGILITY_SITEMAP || "website",
-		languageCode: process.env.AGILITY_LOCALES || "en-ca"
-	})
+	const channelName = process.env.AGILITY_SITEMAP || "website"
+	const languageCode = process.env.AGILITY_LOCALES || "en-ca"
 
-	return Object.keys(sitemap).filter((path) => {
-		const node = sitemap[path]
-		if (node.isFolder || node.redirect) {
-			return false;
-		}
+	//path -> accurate lastmod date for every sitemap-visible URL
+	const lastModifiedMap = await getSitemapLastModifiedMap({ channelName, languageCode })
 
-		if (!node.visible.sitemap) {
-			return false;
-		}
-		return true
-	}).map((path, index) => {
+	const baseUrl = getSiteUrl()
 
-
-
+	return Object.entries(lastModifiedMap).map(([path, lastModified]) => {
+		//the home page lives at "/home" in the sitemap but is served at the root
+		const isHome = path === "/home"
 		return {
-			url: index === 0 ? "https://agilitycms.com/" : `https://agilitycms.com${path}`,
-			lastModified: new Date(),
+			url: isHome ? `${baseUrl}/` : `${baseUrl}${path}`,
+			lastModified: new Date(lastModified),
 			changeFrequency: "daily",
-			priority: 1
+			priority: isHome ? 1 : 0.8
 		}
 	})
 }

--- a/app/sitemap.tsx
+++ b/app/sitemap.tsx
@@ -21,12 +21,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
 	// Emit only <loc> + <lastmod>. Google ignores <changefreq> and <priority>
 	// entirely, and blanket values for them only contradict our accurate lastmod.
+	// When we couldn't determine a reliable date, omit <lastmod> for that URL —
+	// no date is better than a wrong one.
 	return Object.entries(lastModifiedMap).map(([path, lastModified]) => {
 		//the home page lives at "/home" in the sitemap but is served at the root
 		const isHome = path === "/home"
-		return {
-			url: isHome ? `${baseUrl}/` : `${baseUrl}${path}`,
-			lastModified: new Date(lastModified)
-		}
+		const url = isHome ? `${baseUrl}/` : `${baseUrl}${path}`
+		return lastModified ? { url, lastModified: new Date(lastModified) } : { url }
 	})
 }

--- a/lib/cms/getPage.ts
+++ b/lib/cms/getPage.ts
@@ -1,0 +1,26 @@
+import getAgilitySDK from "lib/cms/getAgilitySDK"
+import { cacheConfig } from "lib/cms/cacheConfig"
+import { PageRequestParams } from "@agility/content-fetch/dist/methods/getPage"
+
+/**
+ * Get a page (including its content zones/modules) with caching information added.
+ *
+ * The cache tag matches the one the /api/revalidate webhook busts on a page
+ * publish (`agility-page-${pageID}-${locale}`), so a published page change
+ * propagates to anything built on top of this (e.g. the sitemap lastmod).
+ * @param params
+ * @returns
+ */
+export const getPage = async (params: PageRequestParams) => {
+
+	const agilitySDK = getAgilitySDK()
+
+	agilitySDK.config.fetchConfig = {
+		next: {
+			tags: [`agility-page-${params.pageID}-${params.languageCode || params.locale}`],
+			revalidate: cacheConfig.cacheDuration,
+		},
+	}
+
+	return await agilitySDK.getPage(params)
+}

--- a/lib/cms/getSitemapLastModifiedMap.ts
+++ b/lib/cms/getSitemapLastModifiedMap.ts
@@ -43,6 +43,24 @@ const toMillis = (modified?: string | Date | null): number => {
 	return isNaN(t) ? 0 : t
 }
 
+/**
+ * Retry a fetch that may transiently fail (the Agility fetch API occasionally
+ * returns a 408). The content-fetch SDK logs the error and resolves to
+ * `undefined` rather than throwing, so we retry on a null/undefined result as
+ * well as on a thrown error. Returns undefined if every attempt fails.
+ */
+const withRetry = async <T>(fn: () => Promise<T>, attempts = 3): Promise<T | undefined> => {
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		try {
+			const result = await fn()
+			if (result !== undefined && result !== null) return result
+		} catch {
+			/* transient — fall through and retry */
+		}
+	}
+	return undefined
+}
+
 /** Run an async mapper over items with a bounded number of concurrent workers. */
 const mapWithConcurrency = async <T>(
 	items: T[],
@@ -79,7 +97,13 @@ export const getSitemapLastModifiedMap = async ({
 	languageCode,
 }: SitemapLastModifiedParams): Promise<SitemapLastModifiedMap> => {
 
-	const sitemap = (await getSitemapFlat({ channelName, languageCode })) as Record<string, SitemapNode>
+	const sitemap = (await withRetry(() => getSitemapFlat({ channelName, languageCode }))) as
+		| Record<string, SitemapNode>
+		| undefined
+
+	// Without a sitemap there are no URLs to emit; return empty rather than throw
+	// so a transient API failure can never fail the build.
+	if (!sitemap) return {}
 
 	// Only real, sitemap-visible URLs (skip folders, redirects and hidden pages).
 	const entries = Object.entries(sitemap).filter(([, node]) => {
@@ -108,41 +132,51 @@ export const getSitemapLastModifiedMap = async ({
 
 	await Promise.all(
 		Array.from(dynamicByTemplate.values()).map(async (nodes) => {
-			// Learn the content list's reference name from one representative item.
-			let referenceName: string | undefined
+			// A failure here must never reject the whole build — any dates we can't
+			// resolve in bulk fall through to the per-item pass below.
 			try {
-				const sample = await getContentItem<Record<string, unknown>>({
-					contentID: nodes[0].contentID as number,
-					languageCode,
-				})
-				referenceName = sample?.properties?.referenceName
+				// Learn the content list's reference name from one representative item.
+				const sample = await withRetry(() =>
+					getContentItem<Record<string, unknown>>({
+						contentID: nodes[0].contentID as number,
+						languageCode,
+					})
+				)
+				const referenceName = sample?.properties?.referenceName
 				if (sample?.properties?.modified) {
 					contentModified.set(sample.contentID, toMillis(sample.properties.modified))
 				}
+
+				if (!referenceName) return
+
+				// Page through the whole list, recording every item's modified date.
+				// No sort — we read every item into a map keyed by contentID, so order
+				// is irrelevant and sorting only adds load (and timeout risk) server-side.
+				let skip = 0
+				let total = Number.POSITIVE_INFINITY
+				while (skip < total) {
+					const list = await withRetry(() =>
+						getContentList({
+							referenceName,
+							languageCode,
+							take: CONTENT_LIST_PAGE_SIZE,
+							skip,
+						})
+					)
+
+					// Give up this template's remaining pages on a persistent failure;
+					// the per-item fallback pass fills any gaps.
+					if (!list?.items) break
+
+					total = list.totalCount ?? list.items.length
+					for (const item of list.items) {
+						contentModified.set(item.contentID, toMillis(item.properties?.modified))
+					}
+					if (list.items.length === 0) break
+					skip += CONTENT_LIST_PAGE_SIZE
+				}
 			} catch {
 				/* fall back to per-item fetches below */
-			}
-
-			if (!referenceName) return
-
-			// Page through the whole list, recording every item's modified date.
-			let skip = 0
-			let total = Number.POSITIVE_INFINITY
-			while (skip < total) {
-				const list = await getContentList({
-					referenceName,
-					languageCode,
-					take: CONTENT_LIST_PAGE_SIZE,
-					skip,
-					sort: "properties.modified",
-					direction: "desc",
-				})
-				total = list.totalCount ?? list.items.length
-				for (const item of list.items) {
-					contentModified.set(item.contentID, toMillis(item.properties?.modified))
-				}
-				if (list.items.length === 0) break
-				skip += CONTENT_LIST_PAGE_SIZE
 			}
 		})
 	)
@@ -159,38 +193,34 @@ export const getSitemapLastModifiedMap = async ({
 	}
 
 	await mapWithConcurrency(missingDynamic, STATIC_PAGE_CONCURRENCY, async ([path, node]) => {
-		try {
-			const item = await getContentItem<Record<string, unknown>>({
+		const item = await withRetry(() =>
+			getContentItem<Record<string, unknown>>({
 				contentID: node.contentID as number,
 				languageCode,
 			})
-			result[path] = new Date(toMillis(item?.properties?.modified) || Date.now()).toISOString()
-		} catch {
-			result[path] = new Date().toISOString()
-		}
+		)
+		result[path] = new Date(toMillis(item?.properties?.modified) || Date.now()).toISOString()
 	})
 
 	// --- Static pages --------------------------------------------------------
 	await mapWithConcurrency(staticEntries, STATIC_PAGE_CONCURRENCY, async ([path, node]) => {
 		let latest = 0
-		try {
-			// contentLinkDepth:1 expands each module's content item one level so we can
-			// read its properties.modified. At depth 0 the modules are unexpanded
-			// references with no date, which would collapse to just the page date.
-			const page = await getPage({ pageID: node.pageID, languageCode, contentLinkDepth: 1 })
-			latest = toMillis(page?.properties?.modified)
+		// contentLinkDepth:1 expands each module's content item one level so we can
+		// read its properties.modified. At depth 0 the modules are unexpanded
+		// references with no date, which would collapse to just the page date.
+		const page = await withRetry(() =>
+			getPage({ pageID: node.pageID, languageCode, contentLinkDepth: 1 })
+		)
+		latest = toMillis(page?.properties?.modified)
 
-			const zones = (page?.zones ?? {}) as Record<string, ContentZone[]>
-			for (const zone of Object.values(zones)) {
-				for (const moduleRef of zone ?? []) {
-					// Top-level module content items carry their own modified date.
-					const item = moduleRef?.item as ContentItem | undefined
-					const millis = toMillis(item?.properties?.modified)
-					if (millis > latest) latest = millis
-				}
+		const zones = (page?.zones ?? {}) as Record<string, ContentZone[]>
+		for (const zone of Object.values(zones)) {
+			for (const moduleRef of zone ?? []) {
+				// Top-level module content items carry their own modified date.
+				const item = moduleRef?.item as ContentItem | undefined
+				const millis = toMillis(item?.properties?.modified)
+				if (millis > latest) latest = millis
 			}
-		} catch {
-			/* leave latest as 0 -> falls back to "now" below */
 		}
 		result[path] = new Date(latest || Date.now()).toISOString()
 	})

--- a/lib/cms/getSitemapLastModifiedMap.ts
+++ b/lib/cms/getSitemapLastModifiedMap.ts
@@ -21,9 +21,12 @@ export interface SitemapLastModifiedParams {
 
 /**
  * A map of sitemap path -> the ISO date string that should be used as
- * `<lastmod>` for that URL.
+ * `<lastmod>` for that URL. Every sitemap-visible path is present as a key;
+ * the value is `undefined` when we couldn't determine a reliable date, in which
+ * case the URL should be emitted with no `<lastmod>` at all (an omitted date is
+ * better than a wrong one).
  */
-export type SitemapLastModifiedMap = Record<string, string>
+export type SitemapLastModifiedMap = Record<string, string | undefined>
 
 /**
  * Parse an Agility "modified" value into a millisecond timestamp.
@@ -181,12 +184,17 @@ export const getSitemapLastModifiedMap = async ({
 		})
 	)
 
-	// Assign dynamic dates; fetch individually for any contentID the bulk pass missed.
+	// Assign dynamic dates. A contentID the bulk pass *saw* but with no usable
+	// modified date resolves to `undefined` (omit lastmod). A contentID the bulk
+	// pass never saw is fetched individually below.
 	const missingDynamic: Array<[string, SitemapNode]> = []
 	for (const [path, node] of dynamicEntries) {
-		const millis = contentModified.get(node.contentID as number)
+		const contentID = node.contentID as number
+		const millis = contentModified.get(contentID)
 		if (millis) {
 			result[path] = new Date(millis).toISOString()
+		} else if (contentModified.has(contentID)) {
+			result[path] = undefined
 		} else {
 			missingDynamic.push([path, node])
 		}
@@ -199,7 +207,9 @@ export const getSitemapLastModifiedMap = async ({
 				languageCode,
 			})
 		)
-		result[path] = new Date(toMillis(item?.properties?.modified) || Date.now()).toISOString()
+		const millis = toMillis(item?.properties?.modified)
+		// No reliable date -> leave lastmod out rather than inventing "now".
+		result[path] = millis ? new Date(millis).toISOString() : undefined
 	})
 
 	// --- Static pages --------------------------------------------------------
@@ -222,7 +232,8 @@ export const getSitemapLastModifiedMap = async ({
 				if (millis > latest) latest = millis
 			}
 		}
-		result[path] = new Date(latest || Date.now()).toISOString()
+		// No reliable date (page fetch failed / nothing datable) -> omit lastmod.
+		result[path] = latest ? new Date(latest).toISOString() : undefined
 	})
 
 	return result

--- a/lib/cms/getSitemapLastModifiedMap.ts
+++ b/lib/cms/getSitemapLastModifiedMap.ts
@@ -1,0 +1,199 @@
+import "server-only"
+
+import { getSitemapFlat } from "lib/cms/getSitemapFlat"
+import { getContentItem } from "lib/cms/getContentItem"
+import { getContentList } from "lib/cms/getContentList"
+import { getPage } from "lib/cms/getPage"
+import { SitemapNode } from "lib/types/SitemapNode"
+import { ContentItem } from "@agility/content-fetch"
+import { ContentZone } from "@agility/content-fetch/dist/types/ContentZone"
+
+/** Maximum items the Agility content-fetch API will return in a single list request. */
+const CONTENT_LIST_PAGE_SIZE = 250
+
+/** How many page (zone) lookups to run at once when computing static-page dates. */
+const STATIC_PAGE_CONCURRENCY = 10
+
+export interface SitemapLastModifiedParams {
+	channelName: string
+	languageCode: string
+}
+
+/**
+ * A map of sitemap path -> the ISO date string that should be used as
+ * `<lastmod>` for that URL.
+ */
+export type SitemapLastModifiedMap = Record<string, string>
+
+/**
+ * Parse an Agility "modified" value into a millisecond timestamp.
+ *
+ * Agility returns ISO strings with no timezone offset (e.g. "2026-07-08T23:06:56.673").
+ * JS would interpret those as *local* time, which varies by server. We treat them
+ * as UTC so the result is deterministic regardless of where this runs.
+ */
+const toMillis = (modified?: string | Date | null): number => {
+	if (!modified) return 0
+	if (modified instanceof Date) {
+		const t = modified.getTime()
+		return isNaN(t) ? 0 : t
+	}
+	const hasTimezone = /([zZ])|([+-]\d{2}:?\d{2})$/.test(modified)
+	const t = new Date(hasTimezone ? modified : `${modified}Z`).getTime()
+	return isNaN(t) ? 0 : t
+}
+
+/** Run an async mapper over items with a bounded number of concurrent workers. */
+const mapWithConcurrency = async <T>(
+	items: T[],
+	limit: number,
+	worker: (item: T) => Promise<void>
+): Promise<void> => {
+	let cursor = 0
+	const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		while (cursor < items.length) {
+			const index = cursor++
+			await worker(items[index])
+		}
+	})
+	await Promise.all(runners)
+}
+
+/**
+ * Build a map of sitemap path -> lastmod date for every sitemap-visible URL.
+ *
+ * - Dynamic pages (sitemap node has a `contentID`) use the modified date of the
+ *   backing content item — i.e. the date the actual content changed. To avoid a
+ *   per-URL API call (there can be thousands), dynamic nodes are grouped by their
+ *   dynamic page template (`pageID`) and each template's content list is fetched
+ *   in bulk — a handful of calls instead of one-per-URL.
+ * - Static pages use the most recent of (the page object itself, and every module
+ *   /content item on the page), so publishing new content into a page updates its date.
+ *
+ * Every underlying fetch is individually cached + publish-invalidated via the
+ * existing Agility cache tags, so this is cheap in steady state; a cold rebuild
+ * touches roughly (#dynamic templates * 2) + (#static pages) requests.
+ */
+export const getSitemapLastModifiedMap = async ({
+	channelName,
+	languageCode,
+}: SitemapLastModifiedParams): Promise<SitemapLastModifiedMap> => {
+
+	const sitemap = (await getSitemapFlat({ channelName, languageCode })) as Record<string, SitemapNode>
+
+	// Only real, sitemap-visible URLs (skip folders, redirects and hidden pages).
+	const entries = Object.entries(sitemap).filter(([, node]) => {
+		if (!node) return false
+		if (node.isFolder || node.redirect) return false
+		if (!node.visible?.sitemap) return false
+		return true
+	})
+
+	const dynamicEntries = entries.filter(([, node]) => typeof node.contentID === "number")
+	const staticEntries = entries.filter(([, node]) => typeof node.contentID !== "number")
+
+	const result: SitemapLastModifiedMap = {}
+
+	// --- Dynamic pages -------------------------------------------------------
+	// Group by the dynamic page template so we can bulk-load each list once.
+	const dynamicByTemplate = new Map<number, SitemapNode[]>()
+	for (const [, node] of dynamicEntries) {
+		const group = dynamicByTemplate.get(node.pageID) ?? []
+		group.push(node)
+		dynamicByTemplate.set(node.pageID, group)
+	}
+
+	// contentID -> modified (millis) across every dynamic template.
+	const contentModified = new Map<number, number>()
+
+	await Promise.all(
+		Array.from(dynamicByTemplate.values()).map(async (nodes) => {
+			// Learn the content list's reference name from one representative item.
+			let referenceName: string | undefined
+			try {
+				const sample = await getContentItem<Record<string, unknown>>({
+					contentID: nodes[0].contentID as number,
+					languageCode,
+				})
+				referenceName = sample?.properties?.referenceName
+				if (sample?.properties?.modified) {
+					contentModified.set(sample.contentID, toMillis(sample.properties.modified))
+				}
+			} catch {
+				/* fall back to per-item fetches below */
+			}
+
+			if (!referenceName) return
+
+			// Page through the whole list, recording every item's modified date.
+			let skip = 0
+			let total = Number.POSITIVE_INFINITY
+			while (skip < total) {
+				const list = await getContentList({
+					referenceName,
+					languageCode,
+					take: CONTENT_LIST_PAGE_SIZE,
+					skip,
+					sort: "properties.modified",
+					direction: "desc",
+				})
+				total = list.totalCount ?? list.items.length
+				for (const item of list.items) {
+					contentModified.set(item.contentID, toMillis(item.properties?.modified))
+				}
+				if (list.items.length === 0) break
+				skip += CONTENT_LIST_PAGE_SIZE
+			}
+		})
+	)
+
+	// Assign dynamic dates; fetch individually for any contentID the bulk pass missed.
+	const missingDynamic: Array<[string, SitemapNode]> = []
+	for (const [path, node] of dynamicEntries) {
+		const millis = contentModified.get(node.contentID as number)
+		if (millis) {
+			result[path] = new Date(millis).toISOString()
+		} else {
+			missingDynamic.push([path, node])
+		}
+	}
+
+	await mapWithConcurrency(missingDynamic, STATIC_PAGE_CONCURRENCY, async ([path, node]) => {
+		try {
+			const item = await getContentItem<Record<string, unknown>>({
+				contentID: node.contentID as number,
+				languageCode,
+			})
+			result[path] = new Date(toMillis(item?.properties?.modified) || Date.now()).toISOString()
+		} catch {
+			result[path] = new Date().toISOString()
+		}
+	})
+
+	// --- Static pages --------------------------------------------------------
+	await mapWithConcurrency(staticEntries, STATIC_PAGE_CONCURRENCY, async ([path, node]) => {
+		let latest = 0
+		try {
+			// contentLinkDepth:1 expands each module's content item one level so we can
+			// read its properties.modified. At depth 0 the modules are unexpanded
+			// references with no date, which would collapse to just the page date.
+			const page = await getPage({ pageID: node.pageID, languageCode, contentLinkDepth: 1 })
+			latest = toMillis(page?.properties?.modified)
+
+			const zones = (page?.zones ?? {}) as Record<string, ContentZone[]>
+			for (const zone of Object.values(zones)) {
+				for (const moduleRef of zone ?? []) {
+					// Top-level module content items carry their own modified date.
+					const item = moduleRef?.item as ContentItem | undefined
+					const millis = toMillis(item?.properties?.modified)
+					if (millis > latest) latest = millis
+				}
+			}
+		} catch {
+			/* leave latest as 0 -> falls back to "now" below */
+		}
+		result[path] = new Date(latest || Date.now()).toISOString()
+	})
+
+	return result
+}

--- a/lib/indexnow/submitToIndexNow.ts
+++ b/lib/indexnow/submitToIndexNow.ts
@@ -1,0 +1,102 @@
+import { getSiteUrl } from "lib/utils/getSiteUrl"
+
+/**
+ * Neutral IndexNow endpoint — a submission here is shared with every
+ * participating search engine (Bing, Yandex, Seznam, Naver, …).
+ */
+const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow"
+
+/** IndexNow accepts up to 10,000 URLs per request. */
+const MAX_URLS_PER_REQUEST = 10000
+
+// Read env at call time (not module-load): the crawl/webhook entrypoints may
+// load env vars after this module is imported.
+const getIndexNowKey = () => process.env.INDEXNOW_KEY || ""
+
+/**
+ * Whether we should actually ping IndexNow from this environment. We only want
+ * to submit from the real production site — preview/branch deploys and local
+ * dev must not (their key file isn't reachable at the canonical host, and their
+ * URLs aren't the ones we want recrawled). Set INDEXNOW_ALLOW_NON_PROD=true to
+ * force submission when testing.
+ */
+const isSubmissionEnabled = () =>
+	process.env.VERCEL_ENV === "production" || process.env.INDEXNOW_ALLOW_NON_PROD === "true"
+
+/**
+ * Notify IndexNow-participating search engines that one or more URLs have
+ * changed so they recrawl sooner. Safe to call from a publish webhook.
+ *
+ * Accepts absolute URLs or site-relative paths (paths resolve against the site
+ * base URL). URLs that don't belong to the site host are dropped. No-ops (with
+ * a log line) when the key isn't configured or the environment isn't production.
+ *
+ * @param urls A single URL/path or an array of them.
+ */
+export const submitToIndexNow = async (urls: string | string[]): Promise<void> => {
+	const list = Array.isArray(urls) ? urls : [urls]
+	if (list.length === 0) return
+
+	const key = getIndexNowKey()
+	if (!key) {
+		console.info("IndexNow: INDEXNOW_KEY not set — skipping submission.")
+		return
+	}
+
+	if (!isSubmissionEnabled()) {
+		console.info("IndexNow: not a production environment — skipping submission.")
+		return
+	}
+
+	const baseUrl = getSiteUrl()
+	let host: string
+	try {
+		host = new URL(baseUrl).host
+	} catch {
+		console.error("IndexNow: invalid site base URL, skipping:", baseUrl)
+		return
+	}
+
+	// Resolve to absolute URLs on this host, de-duplicated.
+	const urlList = Array.from(
+		new Set(
+			list
+				.map((u) => {
+					try {
+						const resolved = new URL(u, `${baseUrl}/`)
+						return resolved.host === host ? resolved.toString() : null
+					} catch {
+						return null
+					}
+				})
+				.filter((u): u is string => u !== null)
+		)
+	).slice(0, MAX_URLS_PER_REQUEST)
+
+	if (urlList.length === 0) return
+
+	const body = {
+		host,
+		key,
+		keyLocation: `${baseUrl}/${key}.txt`,
+		urlList
+	}
+
+	try {
+		const res = await fetch(INDEXNOW_ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json; charset=utf-8" },
+			body: JSON.stringify(body),
+			cache: "no-store"
+		})
+
+		if (res.ok) {
+			console.info(`IndexNow: submitted ${urlList.length} url(s).`)
+		} else {
+			// 429 = rate limited; 4xx = key/host problem. Log and move on — this is best-effort.
+			console.error(`IndexNow: submission failed (${res.status} ${res.statusText}) for ${urlList.length} url(s).`)
+		}
+	} catch (e) {
+		console.error("IndexNow: submission error:", e instanceof Error ? e.message : String(e))
+	}
+}

--- a/lib/indexnow/submitToIndexNow.ts
+++ b/lib/indexnow/submitToIndexNow.ts
@@ -87,7 +87,10 @@ export const submitToIndexNow = async (urls: string | string[]): Promise<void> =
 			method: "POST",
 			headers: { "Content-Type": "application/json; charset=utf-8" },
 			body: JSON.stringify(body),
-			cache: "no-store"
+			cache: "no-store",
+			// Best-effort and fired from the publish webhook — never let a hung
+			// endpoint stall the webhook response.
+			signal: AbortSignal.timeout(10000)
 		})
 
 		if (res.ok) {

--- a/lib/utils/getSiteUrl.ts
+++ b/lib/utils/getSiteUrl.ts
@@ -1,0 +1,23 @@
+/**
+ * The public base URL of the site, without a trailing slash.
+ *
+ * Resolution order:
+ *  1. NEXT_PUBLIC_SITE_URL / SITE_URL  — explicit override (always wins)
+ *  2. VERCEL_URL on a non-production deploy — the current preview/branch host
+ *  3. https://agilitycms.com — the canonical production domain
+ *
+ * Production always resolves to the canonical domain because middleware 301s
+ * every other host to agilitycms.com; emitting a Vercel host there would just
+ * produce URLs that redirect. Preview/branch deploys emit their own host so
+ * their sitemap is self-consistent.
+ */
+export const getSiteUrl = (): string => {
+	const explicit = process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL
+	if (explicit) return explicit.replace(/\/+$/, "")
+
+	if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production" && process.env.VERCEL_URL) {
+		return `https://${process.env.VERCEL_URL}`
+	}
+
+	return "https://agilitycms.com"
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,21 @@ export async function middleware(request: NextRequest) {
 	const host = request.nextUrl.host
 	const pathAndQuery = request.nextUrl.pathname + request.nextUrl.search
 
+	//*** IndexNow key verification file ***
+	//Serve the IndexNow key at the site root (/<key>.txt) so search engines can
+	//verify ownership before accepting URL submissions. Must run before the host
+	//canonicalization below so it responds on whatever host the crawler requests.
+	const indexNowKey = process.env.INDEXNOW_KEY
+	if (indexNowKey && request.nextUrl.pathname === `/${indexNowKey}.txt`) {
+		return new NextResponse(indexNowKey, {
+			status: 200,
+			headers: {
+				"Content-Type": "text/plain; charset=utf-8",
+				"Cache-Control": "public, max-age=86400"
+			}
+		})
+	}
+
 	if (!host.startsWith("localhost:") //local (any port)
 		&& !host.endsWith("netlify.app") //netlify
 		&& !host.endsWith("publishwithagility.com") //vercel


### PR DESCRIPTION
## What & why

The XML sitemap set `lastModified: new Date()` on **every** URL, so search engines got no real change signal. This computes an accurate per-URL `lastmod`, and additionally wires publish events to **IndexNow** so participating engines (Bing/Yandex/etc.) recrawl changed pages sooner.

## Sitemap `lastmod`

- **Dynamic pages** → the backing content item's `modified` date (the date the content actually changed).
- **Static pages** → `max(page object date, newest module/content date on the page)`, so publishing content into a page bumps its `lastmod`. Uses `contentLinkDepth:1` to expose module dates (depth 0 returns unexpanded refs with no date).
- **Domain** is now env-driven via `getSiteUrl()` — preview deploys emit their own host; production stays canonical `agilitycms.com`.

### Caching (the important part)
The flat sitemap carries no dates, so dates come from secondary fetches. To avoid hammering the Agility API:
- Dynamic dates are **bulk-loaded per template** (only ~9 unique templates) instead of ~1000 per-URL calls.
- Every fetch rides the existing `agility-content-*` / `agility-page-*` cache tags the publish webhook already invalidates.
- The sitemap route revalidates once/day.

Net: steady-state ≈ 0 API calls; cold rebuild ≈ 120 calls (was ~1000). Verified on the running app — 1102 distinct `lastmod` values, 0 missing; cold 45s → warm 2.9s.

## IndexNow

- `app/api/revalidate/route.ts` pings IndexNow on **page** and **dynamic-page/content** publish, alongside existing Algolia indexing.
- `middleware.ts` serves the key verification file at `/<key>.txt` from the `INDEXNOW_KEY` env var (no committed file).
- Submission is gated to production (`VERCEL_ENV === "production"`, or `INDEXNOW_ALLOW_NON_PROD=true` for testing).

## New env var required
- **`INDEXNOW_KEY`** — set in Vercel (Production) and `.env.local`. Optional: `NEXT_PUBLIC_SITE_URL` to override the sitemap domain.

## Testing
- Sitemap renders 200 with real, varied dates; home `/` correctly reflects its newest module date rather than the older page-object date.
- Key file: `GET /<key>.txt` → 200 `text/plain` with the key; wrong key → 404.
- `tsc --noEmit` and `next lint` clean on all changed files.

## Note
Scoped "most recent content on a page" to the page's **direct modules** (depth 1). A *listing* module (e.g. a page listing blog posts) won't bump its page's date when a listed item changes — but that item's own dynamic URL gets the correct date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
